### PR TITLE
Make playground maps shareable by persisting data to the URL

### DIFF
--- a/docs/content/examples/map-editor.tsx
+++ b/docs/content/examples/map-editor.tsx
@@ -23,13 +23,36 @@ const viewer = {
   username: 'demo-maxima',
 } as const;
 
-const toMapObject = (data: string | null): MapObject | null => {
+const decodeMapObject = (data: string | null): MapObject | null => {
   if (!data) {
     return null;
   }
 
   try {
-    return JSON.parse(data);
+    const json = JSON.parse(data);
+    const mapObject: MapObject = {
+      campaigns: {
+        edges: [],
+      },
+      creator: {
+        displayName:
+          typeof json.creator.displayName === 'string'
+            ? json.creator.displayName
+            : viewer.displayName,
+        id: typeof json.creator.id === 'string' ? json.creator.id : viewer.id,
+        username:
+          typeof json.creator.username === 'string'
+            ? json.creator.username
+            : viewer.username,
+      },
+      effects: typeof json.effects === 'string' ? json.effects : '',
+      id: typeof json.id === 'string' ? json.id : '',
+      name: typeof json.name === 'string' ? json.name : '',
+      slug: typeof json.slug === 'string' ? json.slug : '',
+      state: typeof json.state === 'string' ? json.state : '',
+      tags: Array.isArray(json.tags) ? json.tags : [],
+    };
+    return mapObject;
   } catch {
     return null;
   }
@@ -40,7 +63,7 @@ export default function MapEditorExample() {
   const params = new URLSearchParams(location.search);
 
   const [mapObject, setMapObject] = useState<MapObject | null>(() =>
-    toMapObject(params.get('map')),
+    decodeMapObject(params.get('map')),
   );
 
   const handleMapUpdate = useCallback(

--- a/docs/content/examples/map-editor.tsx
+++ b/docs/content/examples/map-editor.tsx
@@ -90,7 +90,6 @@ export default function MapEditorExample() {
   );
 
   useEffect(() => {
-    // Sync map object to url
     const params = new URLSearchParams(window.location.search);
     params.sort();
     const search = params.toString();

--- a/docs/content/examples/map-editor.tsx
+++ b/docs/content/examples/map-editor.tsx
@@ -1,5 +1,6 @@
 import { encodeEffects } from '@deities/apollo/Effects.tsx';
 import { Sniper } from '@deities/athena/info/Unit.tsx';
+import toSlug from '@deities/hephaestus/toSlug.tsx';
 import MapEditor from '@deities/hera/editor/MapEditor.tsx';
 import {
   MapCreateVariables,
@@ -8,7 +9,6 @@ import {
 } from '@deities/hera/editor/Types.tsx';
 import useLocation from '@deities/ui/hooks/useLocation.tsx';
 import { useEffect, useState } from 'react';
-import toSlug from '../../../hephaestus/toSlug.tsx';
 
 const viewer = {
   access: 'User',

--- a/docs/content/examples/map-editor.tsx
+++ b/docs/content/examples/map-editor.tsx
@@ -8,6 +8,7 @@ import {
 } from '@deities/hera/editor/Types.tsx';
 import useLocation from '@deities/ui/hooks/useLocation.tsx';
 import { useEffect, useState } from 'react';
+import toSlug from '../../../hephaestus/toSlug.tsx';
 
 const viewer = {
   access: 'User',
@@ -22,13 +23,25 @@ const viewer = {
   username: 'demo-maxima',
 } as const;
 
+const toMapObject = (data: string | null): MapObject | null => {
+  if (!data) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
+};
+
 export default function MapEditorExample() {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
 
   const [mapObject, setMapObject] = useState<MapObject | null>(
     // Load map object from url if present
-    JSON.parse(params.get('map') ?? ''),
+    toMapObject(params.get('map')),
   );
 
   const handleMapUpdate = (
@@ -44,11 +57,9 @@ export default function MapEditorExample() {
         username: viewer.username,
       },
       effects: JSON.stringify(encodeEffects(variables.effects)),
-      // TODO: Generate id?
       id: 'id' in variables ? variables.id : '',
       name: variables.mapName,
-      // TODO: Generate slug
-      slug: '',
+      slug: toSlug(variables.mapName),
       state: JSON.stringify(variables.map.toJSON()),
       tags: variables.tags,
     };

--- a/docs/content/examples/map-editor.tsx
+++ b/docs/content/examples/map-editor.tsx
@@ -8,7 +8,7 @@ import {
   MapUpdateVariables,
 } from '@deities/hera/editor/Types.tsx';
 import useLocation from '@deities/ui/hooks/useLocation.tsx';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 const viewer = {
   access: 'User',
@@ -39,32 +39,32 @@ export default function MapEditorExample() {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
 
-  const [mapObject, setMapObject] = useState<MapObject | null>(
-    // Load map object from url if present
+  const [mapObject, setMapObject] = useState<MapObject | null>(() =>
     toMapObject(params.get('map')),
   );
 
-  const handleMapUpdate = (
-    variables: MapCreateVariables | MapUpdateVariables,
-  ) => {
-    const mapObject = {
-      campaigns: {
-        edges: [],
-      },
-      creator: {
-        displayName: viewer.displayName,
-        id: viewer.id,
-        username: viewer.username,
-      },
-      effects: JSON.stringify(encodeEffects(variables.effects)),
-      id: 'id' in variables ? variables.id : '',
-      name: variables.mapName,
-      slug: toSlug(variables.mapName),
-      state: JSON.stringify(variables.map.toJSON()),
-      tags: variables.tags,
-    };
-    setMapObject(mapObject);
-  };
+  const handleMapUpdate = useCallback(
+    (variables: MapCreateVariables | MapUpdateVariables) => {
+      const mapObject = {
+        campaigns: {
+          edges: [],
+        },
+        creator: {
+          displayName: viewer.displayName,
+          id: viewer.id,
+          username: viewer.username,
+        },
+        effects: JSON.stringify(encodeEffects(variables.effects)),
+        id: 'id' in variables ? variables.id : '',
+        name: variables.mapName,
+        slug: toSlug(variables.mapName),
+        state: JSON.stringify(variables.map.toJSON()),
+        tags: variables.tags,
+      };
+      setMapObject(mapObject);
+    },
+    [],
+  );
 
   useEffect(() => {
     // Sync map object to url

--- a/docs/content/examples/map-editor.tsx
+++ b/docs/content/examples/map-editor.tsx
@@ -1,5 +1,13 @@
+import { encodeEffects } from '@deities/apollo/Effects.tsx';
 import { Sniper } from '@deities/athena/info/Unit.tsx';
 import MapEditor from '@deities/hera/editor/MapEditor.tsx';
+import {
+  MapCreateVariables,
+  MapObject,
+  MapUpdateVariables,
+} from '@deities/hera/editor/Types.tsx';
+import useLocation from '@deities/ui/hooks/useLocation.tsx';
+import { useEffect, useState } from 'react';
 
 const viewer = {
   access: 'User',
@@ -15,16 +23,71 @@ const viewer = {
 } as const;
 
 export default function MapEditorExample() {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+
+  const [mapObject, setMapObject] = useState<MapObject | null>(
+    // Load map object from url if present
+    JSON.parse(params.get('map') ?? ''),
+  );
+
+  const handleMapUpdate = (
+    variables: MapCreateVariables | MapUpdateVariables,
+  ) => {
+    const mapObject = {
+      campaigns: {
+        edges: [],
+      },
+      creator: {
+        displayName: viewer.displayName,
+        id: viewer.id,
+        username: viewer.username,
+      },
+      effects: JSON.stringify(encodeEffects(variables.effects)),
+      // TODO: Generate id?
+      id: 'id' in variables ? variables.id : '',
+      name: variables.mapName,
+      // TODO: Generate slug
+      slug: '',
+      state: JSON.stringify(variables.map.toJSON()),
+      tags: variables.tags,
+    };
+    setMapObject(mapObject);
+  };
+
+  useEffect(() => {
+    // Sync map object to url
+    const params = new URLSearchParams(window.location.search);
+    params.sort();
+    const search = params.toString();
+
+    const newParams = new URLSearchParams();
+    if (mapObject) {
+      newParams.set('map', JSON.stringify(mapObject));
+    }
+    newParams.sort();
+    const newSearch = newParams.toString();
+
+    if (newSearch !== search) {
+      window.history.pushState(
+        {},
+        '',
+        window.location.pathname + `${newSearch ? `?${newSearch}` : ``}`,
+      );
+    }
+  }, [mapObject]);
+
   return (
     <div style={{ width: '150%' }}>
       <MapEditor
         animationSpeed={null}
         confirmActionStyle="touch"
-        createMap={() => {}}
+        createMap={handleMapUpdate}
         fogStyle="soft"
+        mapObject={mapObject}
         setHasChanges={() => {}}
         tiltStyle="on"
-        updateMap={() => {}}
+        updateMap={handleMapUpdate}
         user={viewer}
       />
     </div>

--- a/docs/content/examples/map-editor.tsx
+++ b/docs/content/examples/map-editor.tsx
@@ -29,28 +29,40 @@ const decodeMapObject = (data: string | null): MapObject | null => {
   }
 
   try {
-    const json = JSON.parse(data);
+    const maybeMapObject: MapObject | null = JSON.parse(data);
+    const maybeCreator = maybeMapObject?.creator || null;
     const mapObject: MapObject = {
       campaigns: {
         edges: [],
       },
-      creator: {
-        displayName:
-          typeof json.creator.displayName === 'string'
-            ? json.creator.displayName
-            : viewer.displayName,
-        id: typeof json.creator.id === 'string' ? json.creator.id : viewer.id,
-        username:
-          typeof json.creator.username === 'string'
-            ? json.creator.username
-            : viewer.username,
-      },
-      effects: typeof json.effects === 'string' ? json.effects : '',
-      id: typeof json.id === 'string' ? json.id : '',
-      name: typeof json.name === 'string' ? json.name : '',
-      slug: typeof json.slug === 'string' ? json.slug : '',
-      state: typeof json.state === 'string' ? json.state : '',
-      tags: Array.isArray(json.tags) ? json.tags : [],
+      creator: maybeCreator
+        ? {
+            displayName:
+              typeof maybeCreator.displayName === 'string'
+                ? maybeCreator.displayName
+                : viewer.displayName,
+            id:
+              typeof maybeCreator.id === 'string' ? maybeCreator.id : viewer.id,
+            username:
+              typeof maybeCreator.username === 'string'
+                ? maybeCreator.username
+                : viewer.username,
+          }
+        : viewer,
+      effects:
+        typeof maybeMapObject?.effects === 'string'
+          ? maybeMapObject.effects
+          : '',
+      id: typeof maybeMapObject?.id === 'string' ? maybeMapObject.id : '',
+      name: typeof maybeMapObject?.name === 'string' ? maybeMapObject.name : '',
+      slug: typeof maybeMapObject?.slug === 'string' ? maybeMapObject.slug : '',
+      state:
+        typeof maybeMapObject?.state === 'string' ? maybeMapObject.state : '',
+      tags:
+        Array.isArray(maybeMapObject?.tags) &&
+        maybeMapObject.tags.every((tag) => typeof tag === 'string')
+          ? maybeMapObject.tags
+          : [],
     };
     return mapObject;
   } catch {
@@ -68,7 +80,7 @@ export default function MapEditorExample() {
 
   const handleMapUpdate = useCallback(
     (variables: MapCreateVariables | MapUpdateVariables) => {
-      const mapObject = {
+      setMapObject({
         campaigns: {
           edges: [],
         },
@@ -83,8 +95,7 @@ export default function MapEditorExample() {
         slug: toSlug(variables.mapName),
         state: JSON.stringify(variables.map.toJSON()),
         tags: variables.tags,
-      };
-      setMapObject(mapObject);
+      });
     },
     [],
   );

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
     "@deities/apollo": "workspace:*",
     "@deities/art": "workspace:*",
     "@deities/athena": "workspace:*",
+    "@deities/hephaestus": "workspace:*",
     "@deities/hera": "workspace:*",
     "@deities/hermes": "workspace:*",
     "@deities/ui": "workspace:*",

--- a/hera/editor/Types.tsx
+++ b/hera/editor/Types.tsx
@@ -68,22 +68,24 @@ export type SetMapFunction = (
 ) => void;
 
 type MapSaveType = 'New' | 'Update' | 'Disk' | 'Export';
-type MapCreateVariables = Readonly<{
+export type MapCreateVariables = Readonly<{
   effects: Effects;
   map: MapData;
   mapName: string;
   tags: ReadonlyArray<string>;
 }>;
 
+export type MapUpdateVariables = MapCreateVariables &
+  Readonly<{
+    id: string;
+  }>;
+
 export type MapCreateFunction = (
   variables: MapCreateVariables,
   setSaveState: (state: MapEditorSaveState) => void,
 ) => void;
 export type MapUpdateFunction = (
-  variables: MapCreateVariables &
-    Readonly<{
-      id: string;
-    }>,
+  variables: MapUpdateVariables,
   type: MapSaveType,
   setSaveState: (state: MapEditorSaveState) => void,
 ) => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,6 +579,9 @@ importers:
       '@deities/athena':
         specifier: workspace:*
         version: link:../athena
+      '@deities/hephaestus':
+        specifier: workspace:*
+        version: link:../hephaestus
       '@deities/hera':
         specifier: workspace:*
         version: link:../hera


### PR DESCRIPTION
## Description
- Stores map data in the url to make maps created in the playground map editor shareable

Resolves https://github.com/nkzw-tech/athena-crisis/issues/13

## Todo
- [x] Handle `id` and `slug`
