### PR TITLE
feat: add undo-stack on a per map basis

### DIFF
--- a/docs/content/examples/map-editor.tsx
+++ b/docs/content/examples/map-editor.tsx
@@ -80,6 +80,8 @@ export default function MapEditorExample() {
 
   const handleMapUpdate = useCallback(
     (variables: MapCreateVariables | MapUpdateVariables) => {
+      const nameToSlug = toSlug(variables.mapName);
+
       setMapObject({
         campaigns: {
           edges: [],
@@ -90,9 +92,9 @@ export default function MapEditorExample() {
           username: viewer.username,
         },
         effects: JSON.stringify(encodeEffects(variables.effects)),
-        id: 'id' in variables ? variables.id : '',
+        id: 'id' in variables ? variables.id : nameToSlug,
         name: variables.mapName,
-        slug: toSlug(variables.mapName),
+        slug: nameToSlug,
         state: JSON.stringify(variables.map.toJSON()),
         tags: variables.tags,
       });

--- a/docs/content/examples/map-editor.tsx
+++ b/docs/content/examples/map-editor.tsx
@@ -80,7 +80,7 @@ export default function MapEditorExample() {
 
   const handleMapUpdate = useCallback(
     (variables: MapCreateVariables | MapUpdateVariables) => {
-      const nameToSlug = toSlug(variables.mapName);
+      const slug = toSlug(variables.mapName);
 
       setMapObject({
         campaigns: {
@@ -92,9 +92,9 @@ export default function MapEditorExample() {
           username: viewer.username,
         },
         effects: JSON.stringify(encodeEffects(variables.effects)),
-        id: 'id' in variables ? variables.id : nameToSlug,
+        id: 'id' in variables ? variables.id : slug,
         name: variables.mapName,
-        slug: nameToSlug,
+        slug,
         state: JSON.stringify(variables.map.toJSON()),
         tags: variables.tags,
       });

--- a/hera/editor/MapEditor.tsx
+++ b/hera/editor/MapEditor.tsx
@@ -92,8 +92,8 @@ import BiomeIcon from './lib/BiomeIcon.tsx';
 import canFillTile from './lib/canFillTile.tsx';
 import getMapValidationErrorText from './lib/getMapValidationErrorText.tsx';
 import updateUndoStack, {
-  getUndoStackIndexKey,
-  getUndoStackKey,
+  getUndoStackIndexKeyFor,
+  getUndoStackKeyFor,
 } from './lib/updateUndoStack.tsx';
 import ZoomButton from './lib/ZoomButton.tsx';
 import MapEditorControlPanel from './panels/MapEditorControlPanel.tsx';
@@ -130,10 +130,10 @@ export function decodeUndoStack(
 }
 
 const getUndoStack = (id?: string) =>
-  decodeUndoStack(Storage.getItem(getUndoStackKey(id)));
+  decodeUndoStack(Storage.getItem(getUndoStackKeyFor(id)));
 
 const getUndoStackIndex = (id?: string) => {
-  const index = Storage.getItem(getUndoStackIndexKey(id));
+  const index = Storage.getItem(getUndoStackIndexKeyFor(id));
   return index ? Number.parseInt(index, 10) : undefined;
 };
 
@@ -377,7 +377,6 @@ export default function MapEditor({
     useState<PreviousMapEditorState | null>(() => {
       try {
         const effects = Storage.getItem(EFFECTS_KEY) || '';
-
         const stateFromStorage = getInitialMapFromUndoStack(mapObject?.id);
 
         if (!stateFromStorage) {
@@ -548,15 +547,15 @@ export default function MapEditor({
           },
           setSaveState,
         );
-        Storage.removeItem(getUndoStackKey(''));
-        Storage.removeItem(getUndoStackIndexKey(''));
+        Storage.removeItem(getUndoStackKeyFor(''));
+        Storage.removeItem(getUndoStackIndexKeyFor(''));
         Storage.setItem(
-          getUndoStackKey(toSlug(mapName)),
+          getUndoStackKeyFor(toSlug(mapName)),
           JSON.stringify(stack),
         );
         if (editor.undoStackIndex !== null) {
           Storage.setItem(
-            getUndoStackIndexKey(toSlug(mapName)),
+            getUndoStackIndexKeyFor(toSlug(mapName)),
             `${editor?.undoStackIndex}`,
           );
         }
@@ -572,10 +571,13 @@ export default function MapEditor({
           type,
           setSaveState,
         );
-        Storage.setItem(getUndoStackKey(mapObject?.id), JSON.stringify(stack));
+        Storage.setItem(
+          getUndoStackKeyFor(mapObject?.id),
+          JSON.stringify(stack),
+        );
         if (editor.undoStackIndex !== null) {
           Storage.setItem(
-            getUndoStackIndexKey(mapObject?.id),
+            getUndoStackIndexKeyFor(mapObject?.id),
             `${editor?.undoStackIndex}`,
           );
         }
@@ -674,8 +676,11 @@ export default function MapEditor({
                 undoStack.length,
               ),
             );
-            if (Storage.getItem(getUndoStackKey(mapObject?.id)) !== null) {
-              Storage.setItem(getUndoStackIndexKey(mapObject?.id), `${index}`);
+            if (Storage.getItem(getUndoStackKeyFor(mapObject?.id)) !== null) {
+              Storage.setItem(
+                getUndoStackIndexKeyFor(mapObject?.id),
+                `${index}`,
+              );
             }
             if (index > -1 && index < undoStack.length) {
               const [, newMap] = undoStack.at(index) || [];
@@ -795,8 +800,8 @@ export default function MapEditor({
     setMap('reset', newMap);
     _setEditorState(getEditorBaseState(newMap, mapObject, mode, scenario));
     updatePreviousMap();
-    Storage.removeItem(getUndoStackKey(''));
-    Storage.removeItem(getUndoStackIndexKey(''));
+    Storage.removeItem(getUndoStackKeyFor(''));
+    Storage.removeItem(getUndoStackIndexKeyFor(''));
   }, [getInitialMap, mapObject, mode, scenario, setMap, updatePreviousMap]);
 
   const fillMap = useCallback(() => {
@@ -875,7 +880,7 @@ export default function MapEditor({
         key,
         value.toJSON(),
       ]);
-      Storage.setItem(getUndoStackKey(mapObject?.id), JSON.stringify(stack));
+      Storage.setItem(getUndoStackKeyFor(mapObject?.id), JSON.stringify(stack));
     }
   }, [editor.undoStack, mapObject?.id]);
 

--- a/hera/editor/MapEditor.tsx
+++ b/hera/editor/MapEditor.tsx
@@ -795,7 +795,6 @@ export default function MapEditor({
     setMap('reset', newMap);
     _setEditorState(getEditorBaseState(newMap, mapObject, mode, scenario));
     updatePreviousMap();
-    // TODO: delete fallback here
     Storage.removeItem(getUndoStackKey(''));
     Storage.removeItem(getUndoStackIndexKey(''));
   }, [getInitialMap, mapObject, mode, scenario, setMap, updatePreviousMap]);

--- a/hera/editor/Types.tsx
+++ b/hera/editor/Types.tsx
@@ -71,7 +71,6 @@ export type SetMapFunction = (
 type MapSaveType = 'New' | 'Update' | 'Disk' | 'Export';
 export type MapCreateVariables = Readonly<{
   effects: Effects;
-  id: string;
   map: MapData;
   mapName: string;
   tags: ReadonlyArray<string>;

--- a/hera/editor/Types.tsx
+++ b/hera/editor/Types.tsx
@@ -65,11 +65,13 @@ export type SetEditorStateFunction = (editor: Partial<EditorState>) => void;
 export type SetMapFunction = (
   type: 'biome' | 'cleanup' | 'heal' | 'reset' | 'resize' | 'teams',
   map: MapData,
+  undoStack?: UndoStack,
 ) => void;
 
 type MapSaveType = 'New' | 'Update' | 'Disk' | 'Export';
 export type MapCreateVariables = Readonly<{
   effects: Effects;
+  id: string;
   map: MapData;
   mapName: string;
   tags: ReadonlyArray<string>;
@@ -110,6 +112,8 @@ export type MapObject = Readonly<{
 export type PreviousMapEditorState = Readonly<{
   effects: string;
   map: MapData;
+  undoStack?: UndoStack;
+  undoStackIndex?: number;
 }>;
 
 export type MapEditorSaveMessageId =

--- a/hera/editor/lib/updateUndoStack.tsx
+++ b/hera/editor/lib/updateUndoStack.tsx
@@ -1,10 +1,10 @@
 import Storage from '@deities/ui/Storage.tsx';
 import { EditorState, SetEditorStateFunction, UndoEntry } from '../Types.tsx';
 
-export const UNDO_STACK_KEY = (id: string | undefined) =>
+export const getUndoStackKey = (id: string | undefined) =>
   `map-editor-undo-stack-${id ? `${id}` : 'fallback'}`;
 
-export const UNDO_STACK_INDEX_KEY = (id: string | undefined) =>
+export const getUndoStackIndexKey = (id: string | undefined) =>
   `map-editor-undo-stack-index-${id ? `${id}` : 'fallback'}`;
 
 export default function updateUndoStack(
@@ -35,6 +35,6 @@ export default function updateUndoStack(
 
   if (id) {
     const stack = undoStack.map(([key, value]) => [key, value.toJSON()]);
-    Storage.setItem(UNDO_STACK_KEY(id), JSON.stringify(stack));
+    Storage.setItem(getUndoStackKey(id), JSON.stringify(stack));
   }
 }

--- a/hera/editor/lib/updateUndoStack.tsx
+++ b/hera/editor/lib/updateUndoStack.tsx
@@ -1,9 +1,9 @@
 import { EditorState, SetEditorStateFunction, UndoEntry } from '../Types.tsx';
 
-export const getUndoStackKey = (id: string | undefined) =>
+export const getUndoStackKeyFor = (id: string | undefined) =>
   `map-editor-undo-stack-${id ? `${id}` : 'fallback'}`;
 
-export const getUndoStackIndexKey = (id: string | undefined) =>
+export const getUndoStackIndexKeyFor = (id: string | undefined) =>
   `map-editor-undo-stack-index-${id ? `${id}` : 'fallback'}`;
 
 export default function updateUndoStack(

--- a/hera/editor/lib/updateUndoStack.tsx
+++ b/hera/editor/lib/updateUndoStack.tsx
@@ -11,7 +11,7 @@ export default function updateUndoStack(
   { setEditorState }: { setEditorState: SetEditorStateFunction },
   { undoStack, undoStackIndex }: EditorState,
   entry: UndoEntry,
-  id: string | undefined,
+  id?: string,
 ) {
   const lastKey = undoStack.at(
     undoStackIndex != null ? undoStackIndex : -1,
@@ -33,7 +33,8 @@ export default function updateUndoStack(
     undoStackIndex: null,
   });
 
-  const stack = undoStack.map(([key, value]) => [key, value.toJSON()]);
-
-  Storage.setItem(UNDO_STACK_KEY(id), JSON.stringify(stack));
+  if (id) {
+    const stack = undoStack.map(([key, value]) => [key, value.toJSON()]);
+    Storage.setItem(UNDO_STACK_KEY(id), JSON.stringify(stack));
+  }
 }

--- a/hera/editor/lib/updateUndoStack.tsx
+++ b/hera/editor/lib/updateUndoStack.tsx
@@ -1,9 +1,17 @@
+import Storage from '@deities/ui/Storage.tsx';
 import { EditorState, SetEditorStateFunction, UndoEntry } from '../Types.tsx';
+
+export const UNDO_STACK_KEY = (id: string | undefined) =>
+  `map-editor-undo-stack-${id ? `${id}` : 'fallback'}`;
+
+export const UNDO_STACK_INDEX_KEY = (id: string | undefined) =>
+  `map-editor-undo-stack-index-${id ? `${id}` : 'fallback'}`;
 
 export default function updateUndoStack(
   { setEditorState }: { setEditorState: SetEditorStateFunction },
   { undoStack, undoStackIndex }: EditorState,
   entry: UndoEntry,
+  id: string | undefined,
 ) {
   const lastKey = undoStack.at(
     undoStackIndex != null ? undoStackIndex : -1,
@@ -24,4 +32,8 @@ export default function updateUndoStack(
     ],
     undoStackIndex: null,
   });
+
+  const stack = undoStack.map(([key, value]) => [key, value.toJSON()]);
+
+  Storage.setItem(UNDO_STACK_KEY(id), JSON.stringify(stack));
 }

--- a/hera/editor/lib/updateUndoStack.tsx
+++ b/hera/editor/lib/updateUndoStack.tsx
@@ -1,4 +1,3 @@
-import Storage from '@deities/ui/Storage.tsx';
 import { EditorState, SetEditorStateFunction, UndoEntry } from '../Types.tsx';
 
 export const getUndoStackKey = (id: string | undefined) =>
@@ -11,7 +10,6 @@ export default function updateUndoStack(
   { setEditorState }: { setEditorState: SetEditorStateFunction },
   { undoStack, undoStackIndex }: EditorState,
   entry: UndoEntry,
-  id?: string,
 ) {
   const lastKey = undoStack.at(
     undoStackIndex != null ? undoStackIndex : -1,
@@ -32,9 +30,4 @@ export default function updateUndoStack(
     ],
     undoStackIndex: null,
   });
-
-  if (id) {
-    const stack = undoStack.map(([key, value]) => [key, value.toJSON()]);
-    Storage.setItem(getUndoStackKey(id), JSON.stringify(stack));
-  }
 }

--- a/ui/Storage.tsx
+++ b/ui/Storage.tsx
@@ -14,6 +14,10 @@ export default {
     return localStorage.getItem(`${namespace}${key}`);
   },
 
+  removeItem(key: string) {
+    return localStorage.removeItem(`${namespace}${key}`);
+  },
+
   setItem(key: string, value: string) {
     if (value === null) {
       localStorage.removeItem(`${namespace}${key}`);


### PR DESCRIPTION
## Description
Hoping to resolve #3 
Adds the ability to: 
- save the undo stack on reload for unsaved maps
- store undo stacks for saved maps

## Todo
- [x] undo stack on reload one off (need to push)
- [ ] move effects into undostack

Would appreciate any feedback and whether this has hit the mark! :)