### PR TITLE
Skip already-visited tiles during radius calculation (approx. 5% fewer tiles)

### DIFF
--- a/athena/Radius.tsx
+++ b/athena/Radius.tsx
@@ -95,22 +95,25 @@ function calculateRadius(
 
   while (!queue.isEmpty()) {
     const { cost: parentCost, vector } = queue.poll()!;
-    if (closed[map.getTileIndex(vector)]) {
+    const index = map.getTileIndex(vector);
+    if (closed[index]) {
       continue;
     }
+    closed[index] = true;
+
     const vectors = vector.adjacent();
     for (let i = 0; i < vectors.length; i++) {
       const currentVector = vectors[i];
       if (!map.contains(currentVector)) {
         continue;
       }
-      const index = map.getTileIndex(currentVector);
-      if (closed[index] || currentVector.equals(start)) {
+      const currentIndex = map.getTileIndex(currentVector);
+      if (closed[currentIndex]) {
         continue;
       }
       const cost = getCost(map, unit, currentVector);
       if (cost < 0 || !isAccessible(map, unit, currentVector)) {
-        closed[index] = true;
+        closed[currentIndex] = true;
         continue;
       }
       const nextCost =


### PR DESCRIPTION
We have found the shortest path to a given tile when it is dequeued from the priority queue for the first time. There is no shorter path because all other tiles in the priority queue have the same or equal cost from the starting tile (Djikstra).

To keep the implementation simple, this commit uses the existing `closed` array to mark tiles that have been visited. We can also remove the check for `currentVector.equals(start)` because the tile for `start` will already have been put into `closed`.

The tests pass. The number of visited tiles is slightly lower in one of the Radius test cases (added logging to measure this).

The random MapGenerator test perhaps shows a more representative impact. I ran it one time before and after this commit, and looked at the average number of tiles visited in `calculateRadius` during each run: before = 395, after = 372. Of course, there is randomness and it shows we can expect about 5% savings in tiles visited.