### PR TITLE
Fix unit placement for a different team in map editor

### DIFF
--- a/hera/editor/behavior/DesignBehavior.tsx
+++ b/hera/editor/behavior/DesignBehavior.tsx
@@ -241,9 +241,7 @@ export default class DesignBehavior {
     editor: EditorState,
   ): StateLike | null {
     let newState: StateLike | null = null;
-    const players = Array.from(
-      new Set([...state.map.active, ...PlayerIDs.filter((id) => id !== 0)]),
-    ).slice(0, vectors.length);
+    const players = PlayerIDs.filter((id) => id !== 0);
     vectors.forEach((vector, index) => {
       const currentPlayerIndex = players.indexOf(
         state.map.getCurrentPlayer().id,


### PR DESCRIPTION
Closes https://github.com/nkzw-tech/athena-crisis/issues/27

The root cause of this issue was the `Array.slice()` operation below:
```ts
const players = Array.from(
      new Set([...state.map.active, ...PlayerIDs.filter((id) => id !== 0)]),
).slice(0, vectors.length);
```

So when `vectors` is of length 1 (i.e., no mirroring / single player placement), the remainder operation (`%`) below always produces an index 0 (anything is divisible by 1, so n % 1 = 0 for any n):
```ts
const playerId =
    players[
      ((currentPlayerIndex >= 0 ? currentPlayerIndex : 0) + index) %
        players.length
    ];
```

By removing the `slice()` operation above and keeping `players` as `[1,2,3,4,5,6,7]` all the time, multiple-player selection logic is much simpler as well.

For example, 
* when `vectors.length === 2` and `currentPlayerIndex === 3`, player 4 and player 5 will be selected. 
* when `vectors.length === 4` and `currentPlayerIndex === 5`, player 6, player7, player 1, player2 will be selected.

### Single player placement

https://github.com/nkzw-tech/athena-crisis/assets/71210554/4fda8ded-328b-4df2-80d9-d6eb18d75983

### Multiple player (4) placement

https://github.com/nkzw-tech/athena-crisis/assets/71210554/c8fe864f-ba05-4350-9880-289f781be49f

