### PR TITLE
perf: draw portrait with canvas

### DIFF
--- a/art/VariantConfiguration.tsx
+++ b/art/VariantConfiguration.tsx
@@ -65,13 +65,13 @@ export default new Map<SpriteVariant, SpriteVariantConfiguration>([
   [
     'Portraits',
     {
+      asImage: true,
       variantNames: new Set<PlainDynamicPlayerID>([
         ...variantNames,
         -1,
         -2,
         -3,
       ]),
-      asImage: true,
     },
   ],
   [

--- a/art/VariantConfiguration.tsx
+++ b/art/VariantConfiguration.tsx
@@ -71,6 +71,7 @@ export default new Map<SpriteVariant, SpriteVariantConfiguration>([
         -2,
         -3,
       ]),
+      asImage: true,
     },
   ],
   [

--- a/hera/character/Portrait.tsx
+++ b/hera/character/Portrait.tsx
@@ -59,6 +59,7 @@ export default memo(function Portrait({
       },
     ];
     function animateImage() {
+      context.clearRect(0, 0, PortraitWidth, PortraitHeight);
       context.drawImage(
         image,
         positions[currentPosition].x,

--- a/hera/character/Portrait.tsx
+++ b/hera/character/Portrait.tsx
@@ -95,7 +95,6 @@ export default memo(function Portrait({
 });
 
 const portraitStyle = css`
-  contain: content;
   image-rendering: pixelated;
   pointer-events: none;
 `;

--- a/hera/character/Portrait.tsx
+++ b/hera/character/Portrait.tsx
@@ -31,7 +31,6 @@ export default memo(function Portrait({
 }) {
   const ref = useRef<HTMLCanvasElement>(null);
   const hasPortraits = useSprites('portraits');
-
   const { position } = unit.sprite.portrait;
 
   useLayoutEffect(() => {
@@ -46,8 +45,6 @@ export default memo(function Portrait({
 
     const image = spriteImage('Portraits', encodeDynamicPlayerID(player));
     const context = canvas.getContext('2d')!;
-
-    let currentPosition = 0;
     const positions = [
       {
         x: position.x * PortraitWidth,
@@ -58,8 +55,10 @@ export default memo(function Portrait({
         y: (position.y + (variant || 0) + 6) * PortraitHeight,
       },
     ];
-    function animateImage() {
-      context.clearRect(0, 0, PortraitWidth, PortraitHeight);
+    let currentPosition =
+      ((Number(document.timeline.currentTime) || 0) / 1000) % 1 < 0.5 ? 0 : 1;
+
+    const draw = () => {
       context.drawImage(
         image,
         positions[currentPosition].x,
@@ -71,29 +70,27 @@ export default memo(function Portrait({
         PortraitWidth,
         PortraitHeight,
       );
-
       currentPosition = (currentPosition + 1) % positions.length;
-    }
+    };
+
+    draw();
 
     if (animate && !paused) {
-      const interval = setInterval(animateImage, 1000 / positions.length);
+      const interval = setInterval(draw, 1000 / positions.length);
       return () => clearInterval(interval);
     }
-
-    animateImage();
   }, [hasPortraits, animate, paused, player, position, variant]);
 
   return (
-    <div
+    <canvas
       className={cx(portraitStyle, clip && clipStyle)}
+      height={PortraitHeight}
+      ref={ref}
       style={{
-        height: PortraitHeight,
-        width: PortraitWidth,
         zoom: scale,
       }}
-    >
-      <canvas ref={ref}></canvas>
-    </div>
+      width={PortraitWidth}
+    />
   );
 });
 

--- a/hera/character/Portrait.tsx
+++ b/hera/character/Portrait.tsx
@@ -58,7 +58,7 @@ export default memo(function Portrait({
     const context = canvas.getContext('2d')!;
 
     let currentPosition = 0;
-    function animate() {
+    function animateImage() {
       context.drawImage(
         image,
         positions[currentPosition].x,
@@ -75,10 +75,12 @@ export default memo(function Portrait({
     }
 
     if (animate && !paused) {
-      const interval = setInterval(animate, 1000 / positions.length);
+      const interval = setInterval(animateImage, 1000 / positions.length);
       return () => clearInterval(interval);
     }
-  }, [hasPortraits]);
+
+    animateImage();
+  }, [hasPortraits, animate, paused]);
 
   return (
     <div

--- a/hera/character/Portrait.tsx
+++ b/hera/character/Portrait.tsx
@@ -33,11 +33,16 @@ export default memo(function Portrait({
   const hasPortraits = useSprites('portraits');
 
   const { position } = unit.sprite.portrait;
-  const keyFrameYs = [
-    (position.y + (variant || 0)) * PortraitHeight,
-    (position.y + (variant || 0) + 6) * PortraitHeight,
+  const positions = [
+    {
+      x: position.x * PortraitWidth,
+      y: (position.y + (variant || 0)) * PortraitHeight,
+    },
+    {
+      x: position.x * PortraitWidth,
+      y: (position.y + (variant || 0) + 6) * PortraitHeight,
+    },
   ];
-  let curKeyFrameY = 0;
 
   useLayoutEffect(() => {
     if (!hasPortraits) {
@@ -52,11 +57,12 @@ export default memo(function Portrait({
     const image = spriteImage('Portraits', encodeDynamicPlayerID(player));
     const context = canvas.getContext('2d')!;
 
+    let currentPosition = 0;
     function animate() {
       context.drawImage(
         image,
-        position.x * PortraitWidth,
-        keyFrameYs[curKeyFrameY],
+        positions[currentPosition].x,
+        positions[currentPosition].y,
         PortraitWidth,
         PortraitHeight,
         0,
@@ -65,11 +71,11 @@ export default memo(function Portrait({
         PortraitHeight,
       );
 
-      curKeyFrameY = (curKeyFrameY + 1) % keyFrameYs.length;
+      currentPosition = (currentPosition + 1) % positions.length;
     }
 
     if (animate) {
-      setInterval(animate, 1000 / keyFrameYs.length);
+      setInterval(animate, 1000 / positions.length);
     }
   }, [hasPortraits]);
 

--- a/hera/character/Portrait.tsx
+++ b/hera/character/Portrait.tsx
@@ -33,16 +33,6 @@ export default memo(function Portrait({
   const hasPortraits = useSprites('portraits');
 
   const { position } = unit.sprite.portrait;
-  const positions = [
-    {
-      x: position.x * PortraitWidth,
-      y: (position.y + (variant || 0)) * PortraitHeight,
-    },
-    {
-      x: position.x * PortraitWidth,
-      y: (position.y + (variant || 0) + 6) * PortraitHeight,
-    },
-  ];
 
   useLayoutEffect(() => {
     if (!hasPortraits) {
@@ -58,6 +48,16 @@ export default memo(function Portrait({
     const context = canvas.getContext('2d')!;
 
     let currentPosition = 0;
+    const positions = [
+      {
+        x: position.x * PortraitWidth,
+        y: (position.y + (variant || 0)) * PortraitHeight,
+      },
+      {
+        x: position.x * PortraitWidth,
+        y: (position.y + (variant || 0) + 6) * PortraitHeight,
+      },
+    ];
     function animateImage() {
       context.drawImage(
         image,
@@ -80,7 +80,7 @@ export default memo(function Portrait({
     }
 
     animateImage();
-  }, [hasPortraits, animate, paused]);
+  }, [hasPortraits, animate, paused, player, position, variant]);
 
   return (
     <div

--- a/hera/character/Portrait.tsx
+++ b/hera/character/Portrait.tsx
@@ -75,7 +75,8 @@ export default memo(function Portrait({
     }
 
     if (animate) {
-      setInterval(animate, 1000 / positions.length);
+      const interval = setInterval(animate, 1000 / positions.length);
+      return () => clearInterval(interval);
     }
   }, [hasPortraits]);
 

--- a/hera/character/Portrait.tsx
+++ b/hera/character/Portrait.tsx
@@ -74,7 +74,7 @@ export default memo(function Portrait({
       currentPosition = (currentPosition + 1) % positions.length;
     }
 
-    if (animate) {
+    if (animate && !paused) {
       const interval = setInterval(animate, 1000 / positions.length);
       return () => clearInterval(interval);
     }


### PR DESCRIPTION
## Description

Resolves #14 

- store all portrait images in imageMap
  - this is necessary in order to load images with `spriteImage`
- draw portrait with canvas
- animate portrait with `setInterval`

## Memory Usage
- 1000 Portraits

### with img tag (as is)

<img width="1067" alt="image" src="https://github.com/nkzw-tech/athena-crisis/assets/15786615/58261b38-fed7-4753-9136-a9ff2a4b2631">

### with canvas

<img width="1157" alt="Screenshot 2024-05-26 at 05 04 16" src="https://github.com/nkzw-tech/athena-crisis/assets/15786615/64d274ac-8540-4f8e-9f53-729ad0307499">



