### PR TITLE
fix: dark mode colors for game dialog

### DIFF
--- a/hera/ui/GameDialog.tsx
+++ b/hera/ui/GameDialog.tsx
@@ -8,6 +8,7 @@ import isPresent from '@deities/hephaestus/isPresent.tsx';
 import UnknownTypeError from '@deities/hephaestus/UnknownTypeError.tsx';
 import useBlockInput from '@deities/ui/controls/useBlockInput.tsx';
 import useInput from '@deities/ui/controls/useInput.tsx';
+import { applyVar } from '@deities/ui/cssVar.tsx';
 import Dialog, {
   DialogScrollContainer,
   DialogTab,
@@ -259,10 +260,10 @@ const GameInfoPanel = memo(function GameInfoPanel({
         {(typeof panel === 'string' &&
           gameInfoState.panels?.get(panel)?.content) || (
           <Stack gap={16} vertical>
-            <h1>
+            <h1 style={{ color: applyVar('text-color') }}>
               <fbt desc="Headline for describing how to win">How to win</fbt>
             </h1>
-            <p>
+            <p style={{ color: applyVar('text-color') }}>
               {conditions.length ? (
                 <fbt desc="Description of how to win">
                   Complete any win condition to win the game.

--- a/hera/win-conditions/WinConditionDescription.tsx
+++ b/hera/win-conditions/WinConditionDescription.tsx
@@ -426,6 +426,7 @@ export default function WinConditionDescription({
           condition.type !== WinCriteria.Default && condition.players?.length
             ? gradient(condition.players, 0.15)
             : applyVar('background-color'),
+        color: applyVar('text-color'),
       }}
       vertical
     >


### PR DESCRIPTION
The content isn't accessible in dark mode hence I have updated the colors.

Before
<img width="611" alt="Screenshot 2024-05-30 at 11 50 03 AM" src="https://github.com/nkzw-tech/athena-crisis/assets/11256141/388ae976-db96-4379-a74d-02d589ebe3ff">

Now
<img width="608" alt="Screenshot 2024-05-30 at 12 08 03 PM" src="https://github.com/nkzw-tech/athena-crisis/assets/11256141/95ec58b7-4116-4be1-90a4-c3c034d47420">

cc @cpojer 