### PR TITLE
Improve PlayerCard UI

### DIFF
--- a/hera/ui/PlayerCard.tsx
+++ b/hera/ui/PlayerCard.tsx
@@ -307,15 +307,8 @@ export default memo(function PlayerCard({
             </Stack>
             {wide && (
               <Stack className={offsetStyle} gap={16} nowrap>
-                <Stack
-                  className={cx(playerStatsStyle, nowrapStyle)}
-                  key="funds-per-turn"
-                >
-                  <Icon
-                    className={playerStatsBeforeIconStyle}
-                    icon={Reload}
-                    key="icon"
-                  />
+                <Stack className={cx(playerStatsStyle, nowrapStyle)}>
+                  <Icon className={playerStatsBeforeIconStyle} icon={Reload} />
                   <span>
                     {shouldShow ? calculateFunds(map, player) : '???'}
                   </span>


### PR DESCRIPTION
Related to the discussions: https://github.com/nkzw-tech/athena-crisis/pull/34#issuecomment-2141532150, https://github.com/nkzw-tech/athena-crisis/pull/34#issuecomment-2141675890

I added `flex-shrink: 0;` to `fundStyle` and I hope it's okay..? since if I don't have it, the collapsed UI would look like:

<img width="304" alt="Screenshot 2024-05-31 at 10 11 19 PM" src="https://github.com/nkzw-tech/athena-crisis/assets/71210554/b3876058-3ee7-4a05-8d1e-c0209cca5ee1">

whereas if I have `flex-shrink: 0;`:

<img width="304" alt="Screenshot 2024-05-31 at 10 11 03 PM" src="https://github.com/nkzw-tech/athena-crisis/assets/71210554/932d57c1-c995-4c93-8d85-a578b82aef7c">

And when the card is expanded, the data is arranged in a way that the funds (funds & funds per turn) are left-aligned and all the other info (which is wrapped in a `<Stack>`) is right-aligned:

<img width="540" alt="Screenshot 2024-05-31 at 10 05 31 PM" src="https://github.com/nkzw-tech/athena-crisis/assets/71210554/de8d939f-2afa-4ca3-b950-91ac8f1ff65f">

Lastly, the added condition to the `winConditions.filter()`&mdash;`!condition.completed?.has(player.id)`)&mdash;ensures that optional objectives are not shown on the screen once completed.

P.S. Sorry, the generated diff looks very unintuitive 😅