### PR TITLE
Easy ~1.2x speedup for calculateRadius

### DIFF
--- a/athena/Radius.tsx
+++ b/athena/Radius.tsx
@@ -136,7 +136,11 @@ function calculateRadius(
           vector: currentVector,
         };
         paths.set(currentVector, item);
-        queue.add(item);
+
+        // we only need to check neighbors if we have remaining wiggle-room
+        if (nextCost < radius) {
+          queue.add(item);
+        }
       }
     }
   }

--- a/athena/Radius.tsx
+++ b/athena/Radius.tsx
@@ -136,8 +136,6 @@ function calculateRadius(
           vector: currentVector,
         };
         paths.set(currentVector, item);
-
-        // we only need to check neighbors if we have remaining wiggle-room
         if (nextCost < radius) {
           queue.add(item);
         }


### PR DESCRIPTION
This adds an optimization to avoid calculating where you can go from a position if you have already maxed out.

Small note that if there is a positive, minimum cost to making a move then the if statement could be expanded to

```
if (nextCost + minMove <= radius) {
```

There is no formal benchmarking system in the repo, so this just used a homebrewed one. The (fairly unscientific) results were speedups ranging from 1.15x to 1.3x

This is to aid in https://github.com/nkzw-tech/athena-crisis/issues/9