### PR TITLE
Add optional win condition amount feature

### DIFF
--- a/apollo/ActionMap.json
+++ b/apollo/ActionMap.json
@@ -172,5 +172,6 @@
   ["ActivatePower", [40, ["type", "skill"]]],
   ["PreviousTurnGameOver", [41, ["type", "fromPlayer"]]],
   ["SecretDiscovered", [42, ["type", "condition"]]],
-  ["OptionalObjective", [43, ["type", "condition", "conditionId", "toPlayer"]]]
+  ["OptionalObjective", [43, ["type", "condition", "conditionId", "toPlayer"]]],
+  ["DeniedOptionalObjective", [44, ["type", "condition", "conditionId"]]]
 ]

--- a/apollo/actions/applyActionResponse.tsx
+++ b/apollo/actions/applyActionResponse.tsx
@@ -481,6 +481,7 @@ export default function applyActionResponse(
     case 'HiddenTargetAttackUnit':
       return applyHiddenActionResponse(map, vision, actionResponse);
     case 'OptionalObjective':
+    case 'DeniedOptionalObjective':
     case 'AttackUnitGameOver':
     case 'BeginTurnGameOver':
     case 'CaptureGameOver':

--- a/apollo/lib/checkWinCondition.tsx
+++ b/apollo/lib/checkWinCondition.tsx
@@ -331,6 +331,9 @@ function checkOptionalObjectiveAmountWinCondition(
     for (const condition of winConditions) {
       if (
         condition.type === WinCriteria.OptionalObjectiveAmount &&
+        (!condition.players ||
+          condition.players.length === 0 ||
+          condition.players.includes(actionResponse.toPlayer)) &&
         completedObjectiveCount >= condition.amount
       ) {
         return condition;
@@ -339,7 +342,7 @@ function checkOptionalObjectiveAmountWinCondition(
   } else if (
     actionResponse.type === 'DeniedOptionalObjective' &&
     actionResponse.condition.type !== WinCriteria.Default &&
-    actionResponse.condition.failed
+    actionResponse.condition.failed?.size
   ) {
     for (const deniedPlayer of actionResponse.condition.failed) {
       const viableObjectiveCount = winConditions.filter(

--- a/apollo/lib/checkWinCondition.tsx
+++ b/apollo/lib/checkWinCondition.tsx
@@ -375,12 +375,17 @@ export default function checkWinConditions(
     return null;
   }
 
-  const optionalObjectiveAmount = checkOptionalObjectiveAmountWinCondition(
-    map,
-    actionResponse,
-  );
-  if (optionalObjectiveAmount) {
-    return optionalObjectiveAmount;
+  if (
+    actionResponse.type === 'OptionalObjective' ||
+    actionResponse.type === 'DeniedOptionalObjective'
+  ) {
+    const optionalObjectiveAmount = checkOptionalObjectiveAmountWinCondition(
+      map,
+      actionResponse,
+    );
+    if (optionalObjectiveAmount) {
+      return optionalObjectiveAmount;
+    }
   }
 
   const isDestructive = isDestructiveAction(actionResponse);

--- a/apollo/lib/computeVisibleActions.tsx
+++ b/apollo/lib/computeVisibleActions.tsx
@@ -263,6 +263,7 @@ const VisibleActionModifiers: Record<
       unit,
     }),
   },
+  DeniedOptionalObjective: true,
   DropUnit: {
     Both: true,
     Source: true,

--- a/apollo/lib/dropLabelsFromActionResponse.tsx
+++ b/apollo/lib/dropLabelsFromActionResponse.tsx
@@ -63,6 +63,7 @@ export default function dropLabelsFromActionResponse(
     case 'HiddenFundAdjustment':
     case 'Message':
     case 'OptionalObjective':
+    case 'DeniedOptionalObjective':
     case 'PreviousTurnGameOver':
     case 'ReceiveReward':
     case 'SecretDiscovered':

--- a/apollo/lib/getActionResponseVectors.tsx
+++ b/apollo/lib/getActionResponseVectors.tsx
@@ -88,6 +88,7 @@ export default function getActionResponseVectors(
     case 'HiddenFundAdjustment':
     case 'Message':
     case 'OptionalObjective':
+    case 'DeniedOptionalObjective':
     case 'PreviousTurnGameOver':
     case 'ReceiveReward':
     case 'SecretDiscovered':

--- a/athena/WinConditions.tsx
+++ b/athena/WinConditions.tsx
@@ -29,6 +29,7 @@ export enum WinCriteria {
   DefeatOneLabel = 10,
   DestroyLabel = 11,
   DestroyAmount = 12,
+  OptionalObjectiveAmount = 13,
 }
 
 export const WinCriteriaList = [
@@ -44,6 +45,7 @@ export const WinCriteriaList = [
   WinCriteria.RescueLabel,
   WinCriteria.DestroyLabel,
   WinCriteria.DestroyAmount,
+  WinCriteria.OptionalObjectiveAmount,
 ] as const;
 
 export const WinCriteriaListWithoutDefault = [
@@ -58,6 +60,7 @@ export const WinCriteriaListWithoutDefault = [
   WinCriteria.DefeatOneLabel,
   WinCriteria.DestroyLabel,
   WinCriteria.DestroyAmount,
+  WinCriteria.OptionalObjectiveAmount,
 ] as const;
 
 export const MIN_AMOUNT = 1;
@@ -67,6 +70,7 @@ export const MAX_ROUNDS = 1024;
 
 type CaptureLabelWinCondition = Readonly<{
   completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
   hidden: boolean;
   label: PlayerIDSet;
   optional: boolean;
@@ -78,6 +82,7 @@ type CaptureLabelWinCondition = Readonly<{
 type CaptureAmountWinCondition = Readonly<{
   amount: number;
   completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
   hidden: boolean;
   optional: boolean;
   players?: PlayerIDs;
@@ -87,6 +92,7 @@ type CaptureAmountWinCondition = Readonly<{
 
 type DefeatWinCondition = Readonly<{
   completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
   hidden: boolean;
   label: PlayerIDSet;
   optional: boolean;
@@ -97,6 +103,7 @@ type DefeatWinCondition = Readonly<{
 
 type SurvivalWinCondition = Readonly<{
   completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
   hidden: boolean;
   optional: boolean;
   players: PlayerIDs;
@@ -107,6 +114,7 @@ type SurvivalWinCondition = Readonly<{
 
 type EscortLabelWinCondition = Readonly<{
   completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
   hidden: boolean;
   label: PlayerIDSet;
   optional: boolean;
@@ -119,6 +127,7 @@ type EscortLabelWinCondition = Readonly<{
 type EscortAmountWinCondition = Readonly<{
   amount: number;
   completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
   hidden: boolean;
   label?: PlayerIDSet;
   optional: boolean;
@@ -130,6 +139,7 @@ type EscortAmountWinCondition = Readonly<{
 
 type RescueLabelWinCondition = Readonly<{
   completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
   hidden: boolean;
   label: PlayerIDSet;
   optional: boolean;
@@ -141,6 +151,7 @@ type RescueLabelWinCondition = Readonly<{
 type DefeatAmountWinCondition = Readonly<{
   amount: number;
   completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
   hidden: boolean;
   optional: boolean;
   players?: PlayerIDs;
@@ -150,6 +161,7 @@ type DefeatAmountWinCondition = Readonly<{
 
 type DefeatOneLabelWinCondition = Readonly<{
   completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
   hidden: boolean;
   label: PlayerIDSet;
   optional: boolean;
@@ -160,6 +172,7 @@ type DefeatOneLabelWinCondition = Readonly<{
 
 type DestroyLabelWinCondition = Readonly<{
   completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
   hidden: boolean;
   label: PlayerIDSet;
   optional: boolean;
@@ -171,11 +184,23 @@ type DestroyLabelWinCondition = Readonly<{
 type DestroyAmountWinCondition = Readonly<{
   amount: number;
   completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
   hidden: boolean;
   optional: boolean;
   players?: PlayerIDs;
   reward?: Reward | null;
   type: WinCriteria.DestroyAmount;
+}>;
+
+type OptionalObjectiveAmountWinCondition = Readonly<{
+  amount: number;
+  completed?: PlayerIDSet;
+  failed?: PlayerIDSet;
+  hidden: boolean;
+  optional: boolean;
+  players?: PlayerIDs;
+  reward?: Reward | null;
+  type: WinCriteria.OptionalObjectiveAmount;
 }>;
 
 export type WinConditionsWithVectors =
@@ -198,7 +223,8 @@ export type WinCondition =
   | EscortAmountWinCondition
   | EscortLabelWinCondition
   | RescueLabelWinCondition
-  | SurvivalWinCondition;
+  | SurvivalWinCondition
+  | OptionalObjectiveAmountWinCondition;
 
 export type PlainWinCondition =
   | [
@@ -207,6 +233,7 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ]
   | [
       type: WinCriteria.CaptureLabel,
@@ -216,6 +243,7 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ]
   | [
       type: WinCriteria.CaptureAmount,
@@ -225,6 +253,7 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ]
   | [
       type: WinCriteria.DefeatLabel,
@@ -234,6 +263,7 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ]
   | [
       type: WinCriteria.EscortLabel,
@@ -244,6 +274,7 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ]
   | [
       type: WinCriteria.Survival,
@@ -253,6 +284,7 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ]
   | [
       type: WinCriteria.EscortAmount,
@@ -264,6 +296,7 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ]
   | [
       type: WinCriteria.RescueLabel,
@@ -273,6 +306,7 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ]
   | [
       type: WinCriteria.DefeatAmount,
@@ -282,6 +316,7 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ]
   | [
       type: WinCriteria.DefeatOneLabel,
@@ -291,6 +326,7 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ]
   | [
       type: WinCriteria.DestroyLabel,
@@ -300,6 +336,7 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ]
   | [
       type: WinCriteria.DestroyAmount,
@@ -309,6 +346,17 @@ export type PlainWinCondition =
       reward?: EncodedReward | null,
       optional?: 0 | 1,
       completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
+    ]
+  | [
+      type: WinCriteria.OptionalObjectiveAmount,
+      hidden: 0 | 1,
+      amount: number,
+      players: ReadonlyArray<number>,
+      reward?: EncodedReward | null,
+      optional?: 0 | 1,
+      completed?: ReadonlyArray<number>,
+      failed?: ReadonlyArray<number>,
     ];
 
 export type WinConditions = ReadonlyArray<WinCondition>;
@@ -329,6 +377,7 @@ export function encodeWinCondition(condition: WinCondition): PlainWinCondition {
         maybeEncodeReward(condition.reward),
         condition.optional ? 1 : 0,
         condition.completed?.size ? Array.from(condition.completed) : [],
+        condition.failed?.size ? Array.from(condition.failed) : [],
       ];
     case WinCriteria.CaptureAmount:
     case WinCriteria.DestroyAmount:
@@ -340,6 +389,7 @@ export function encodeWinCondition(condition: WinCondition): PlainWinCondition {
         maybeEncodeReward(condition.reward),
         condition.optional ? 1 : 0,
         condition.completed?.size ? Array.from(condition.completed) : [],
+        condition.failed?.size ? Array.from(condition.failed) : [],
       ];
     case WinCriteria.DefeatLabel:
       return [
@@ -350,6 +400,7 @@ export function encodeWinCondition(condition: WinCondition): PlainWinCondition {
         maybeEncodeReward(condition.reward),
         condition.optional ? 1 : 0,
         condition.completed?.size ? Array.from(condition.completed) : [],
+        condition.failed?.size ? Array.from(condition.failed) : [],
       ];
     case WinCriteria.EscortLabel:
       return [
@@ -361,6 +412,7 @@ export function encodeWinCondition(condition: WinCondition): PlainWinCondition {
         maybeEncodeReward(condition.reward),
         condition.optional ? 1 : 0,
         condition.completed?.size ? Array.from(condition.completed) : [],
+        condition.failed?.size ? Array.from(condition.failed) : [],
       ];
     case WinCriteria.Survival:
       return [
@@ -371,6 +423,7 @@ export function encodeWinCondition(condition: WinCondition): PlainWinCondition {
         maybeEncodeReward(condition.reward),
         condition.optional ? 1 : 0,
         condition.completed?.size ? Array.from(condition.completed) : [],
+        condition.failed?.size ? Array.from(condition.failed) : [],
       ];
     case WinCriteria.EscortAmount:
       return [
@@ -383,6 +436,7 @@ export function encodeWinCondition(condition: WinCondition): PlainWinCondition {
         maybeEncodeReward(condition.reward),
         condition.optional ? 1 : 0,
         condition.completed?.size ? Array.from(condition.completed) : [],
+        condition.failed?.size ? Array.from(condition.failed) : [],
       ];
     case WinCriteria.RescueLabel:
       return [
@@ -393,6 +447,7 @@ export function encodeWinCondition(condition: WinCondition): PlainWinCondition {
         maybeEncodeReward(condition.reward),
         condition.optional ? 1 : 0,
         condition.completed?.size ? Array.from(condition.completed) : [],
+        condition.failed?.size ? Array.from(condition.failed) : [],
       ];
     case WinCriteria.DefeatAmount:
       return [
@@ -403,6 +458,7 @@ export function encodeWinCondition(condition: WinCondition): PlainWinCondition {
         maybeEncodeReward(condition.reward),
         condition.optional ? 1 : 0,
         condition.completed?.size ? Array.from(condition.completed) : [],
+        condition.failed?.size ? Array.from(condition.failed) : [],
       ];
     case WinCriteria.DefeatOneLabel:
       return [
@@ -413,6 +469,18 @@ export function encodeWinCondition(condition: WinCondition): PlainWinCondition {
         maybeEncodeReward(condition.reward),
         condition.optional ? 1 : 0,
         condition.completed?.size ? Array.from(condition.completed) : [],
+        condition.failed?.size ? Array.from(condition.failed) : [],
+      ];
+    case WinCriteria.OptionalObjectiveAmount:
+      return [
+        type,
+        hidden ? 1 : 0,
+        condition.amount,
+        condition.players || [],
+        maybeEncodeReward(condition.reward),
+        condition.optional ? 1 : 0,
+        condition.completed?.size ? Array.from(condition.completed) : [],
+        condition.failed?.size ? Array.from(condition.failed) : [],
       ];
     default: {
       condition satisfies never;
@@ -437,6 +505,7 @@ export function decodeWinCondition(condition: PlainWinCondition): WinCondition {
         completed: condition[6]
           ? new Set(toPlayerIDs(condition[6]))
           : new Set(),
+        failed: condition[7] ? new Set(toPlayerIDs(condition[7])) : new Set(),
         hidden: !!condition[1],
         label: new Set(toPlayerIDs(condition[2])),
         optional: !!condition[5],
@@ -451,6 +520,7 @@ export function decodeWinCondition(condition: PlainWinCondition): WinCondition {
         completed: condition[6]
           ? new Set(toPlayerIDs(condition[6]))
           : new Set(),
+        failed: condition[7] ? new Set(toPlayerIDs(condition[7])) : new Set(),
         hidden: !!condition[1],
         optional: !!condition[5],
         players: condition[3] ? toPlayerIDs(condition[3]) : undefined,
@@ -462,6 +532,7 @@ export function decodeWinCondition(condition: PlainWinCondition): WinCondition {
         completed: condition[6]
           ? new Set(toPlayerIDs(condition[6]))
           : new Set(),
+        failed: condition[7] ? new Set(toPlayerIDs(condition[7])) : new Set(),
         hidden: !!condition[1],
         label: new Set(toPlayerIDs(condition[2])),
         optional: !!condition[5],
@@ -474,6 +545,7 @@ export function decodeWinCondition(condition: PlainWinCondition): WinCondition {
         completed: condition[7]
           ? new Set(toPlayerIDs(condition[7]))
           : new Set(),
+        failed: condition[8] ? new Set(toPlayerIDs(condition[8])) : new Set(),
         hidden: !!condition[1],
         label: new Set(toPlayerIDs(condition[2])),
         optional: !!condition[6],
@@ -487,6 +559,7 @@ export function decodeWinCondition(condition: PlainWinCondition): WinCondition {
         completed: condition[6]
           ? new Set(toPlayerIDs(condition[6]))
           : new Set(),
+        failed: condition[7] ? new Set(toPlayerIDs(condition[7])) : new Set(),
         hidden: !!condition[1],
         optional: !!condition[5],
         players: toPlayerIDs(condition[3]),
@@ -500,6 +573,7 @@ export function decodeWinCondition(condition: PlainWinCondition): WinCondition {
         completed: condition[8]
           ? new Set(toPlayerIDs(condition[8]))
           : new Set(),
+        failed: condition[9] ? new Set(toPlayerIDs(condition[9])) : new Set(),
         hidden: !!condition[1],
         label: condition[5] ? new Set(toPlayerIDs(condition[5])) : undefined,
         optional: !!condition[7],
@@ -513,6 +587,7 @@ export function decodeWinCondition(condition: PlainWinCondition): WinCondition {
         completed: condition[6]
           ? new Set(toPlayerIDs(condition[6]))
           : new Set(),
+        failed: condition[7] ? new Set(toPlayerIDs(condition[7])) : new Set(),
         hidden: !!condition[1],
         label: new Set(toPlayerIDs(condition[2])),
         optional: !!condition[5],
@@ -526,6 +601,7 @@ export function decodeWinCondition(condition: PlainWinCondition): WinCondition {
         completed: condition[6]
           ? new Set(toPlayerIDs(condition[6]))
           : new Set(),
+        failed: condition[7] ? new Set(toPlayerIDs(condition[7])) : new Set(),
         hidden: !!condition[1],
         optional: !!condition[5],
         players: toPlayerIDs(condition[3]),
@@ -537,10 +613,24 @@ export function decodeWinCondition(condition: PlainWinCondition): WinCondition {
         completed: condition[6]
           ? new Set(toPlayerIDs(condition[6]))
           : new Set(),
+        failed: condition[7] ? new Set(toPlayerIDs(condition[7])) : new Set(),
         hidden: !!condition[1],
         label: condition[2] ? new Set(toPlayerIDs(condition[2])) : new Set(),
         optional: !!condition[5],
         players: condition[3] ? toPlayerIDs(condition[3]) : undefined,
+        reward: maybeDecodeReward(condition[4]),
+        type,
+      };
+    case WinCriteria.OptionalObjectiveAmount:
+      return {
+        amount: condition[2],
+        completed: condition[6]
+          ? new Set(toPlayerIDs(condition[6]))
+          : new Set(),
+        failed: condition[7] ? new Set(toPlayerIDs(condition[7])) : new Set(),
+        hidden: !!condition[1],
+        optional: !!condition[5],
+        players: toPlayerIDs(condition[3]),
         reward: maybeDecodeReward(condition[4]),
         type,
       };
@@ -608,13 +698,15 @@ export function winConditionHasAmounts(
   | CaptureAmountWinCondition
   | DefeatAmountWinCondition
   | DestroyAmountWinCondition
-  | EscortAmountWinCondition {
+  | EscortAmountWinCondition
+  | OptionalObjectiveAmountWinCondition {
   const { type } = condition;
   return (
     type === WinCriteria.CaptureAmount ||
     type === WinCriteria.DestroyAmount ||
     type === WinCriteria.DefeatAmount ||
-    type === WinCriteria.EscortAmount
+    type === WinCriteria.EscortAmount ||
+    type === WinCriteria.OptionalObjectiveAmount
   );
 }
 
@@ -683,7 +775,8 @@ export function validateWinCondition(map: MapData, condition: WinCondition) {
   if (
     (hidden !== false && hidden !== true) ||
     (condition.reward && !validateReward(condition.reward)) ||
-    (type !== WinCriteria.Default && condition.completed?.size)
+    (type !== WinCriteria.Default && condition.completed?.size) ||
+    (type !== WinCriteria.Default && condition.failed?.size)
   ) {
     return false;
   }
@@ -753,6 +846,24 @@ export function validateWinCondition(map: MapData, condition: WinCondition) {
         validatePlayers(map, toPlayerIDs(condition.players)) &&
         [...condition.vectors].every(validateVector)
       );
+    case WinCriteria.OptionalObjectiveAmount: {
+      if (!validateAmount(condition.amount)) {
+        return false;
+      }
+
+      const optionalObjectiveCount = map.config.winConditions.filter(
+        (condition) =>
+          condition.type !== WinCriteria.Default &&
+          condition.type !== WinCriteria.OptionalObjectiveAmount &&
+          condition.optional,
+      ).length;
+
+      if (optionalObjectiveCount < condition.amount) {
+        return false;
+      }
+
+      return true;
+    }
     default: {
       condition satisfies never;
       return false;
@@ -788,10 +899,11 @@ export function resetWinConditions(
 ): WinConditions {
   return conditions.map((condition) =>
     condition.type === WinCriteria.Default || !condition.players
-      ? { ...condition, completed: new Set() }
+      ? { ...condition, completed: new Set(), failed: new Set() }
       : ({
           ...condition,
           completed: new Set(),
+          failed: new Set(),
           players: condition.players.filter((player) => active.has(player)),
         } as const),
   );
@@ -913,6 +1025,14 @@ export function getInitialWinCondition(
         hidden,
         label,
         optional,
+        type: criteria,
+      };
+    case WinCriteria.OptionalObjectiveAmount:
+      return {
+        amount: 0,
+        hidden,
+        optional,
+        players,
         type: criteria,
       };
     default: {

--- a/hera/action-response/processActionResponse.tsx
+++ b/hera/action-response/processActionResponse.tsx
@@ -624,6 +624,9 @@ async function processActionResponse(
     case 'OptionalObjective':
     case 'SecretDiscovered':
       return secretDiscoveredAnimation(newMap, actions, state, actionResponse);
+    case 'DeniedOptionalObjective': {
+      break;
+    }
     default: {
       actionResponse satisfies never;
       throw new UnknownTypeError('processActionResponse', type);

--- a/hera/editor/lib/WinConditionCard.tsx
+++ b/hera/editor/lib/WinConditionCard.tsx
@@ -140,13 +140,13 @@ export default function WinConditionCard({
                   min={MIN_AMOUNT}
                   onChange={({ target: { value } }) => {
                     const amount = parseInteger(value);
+                    setAmount(amount);
                     if (amount) {
                       const newCondition = {
                         ...condition,
                         amount,
                       };
                       if (validate(newCondition)) {
-                        setAmount(amount);
                         onChange(newCondition);
                       }
                     }

--- a/hera/editor/lib/WinConditionCard.tsx
+++ b/hera/editor/lib/WinConditionCard.tsx
@@ -140,13 +140,13 @@ export default function WinConditionCard({
                   min={MIN_AMOUNT}
                   onChange={({ target: { value } }) => {
                     const amount = parseInteger(value);
-                    setAmount(amount);
                     if (amount) {
                       const newCondition = {
                         ...condition,
                         amount,
                       };
                       if (validate(newCondition)) {
+                        setAmount(amount);
                         onChange(newCondition);
                       }
                     }

--- a/hera/lib/getWinCriteriaName.tsx
+++ b/hera/lib/getWinCriteriaName.tsx
@@ -58,6 +58,11 @@ export default function getWinCriteriaName(criteria: WinCriteria) {
         'Destroy buildings by amount',
         'Panel button name for destroy by amount.',
       );
+    case WinCriteria.OptionalObjectiveAmount:
+      return fbt(
+        'Complete optional objectives by amount',
+        'Panel button name for complete optional objectives by amount.',
+      );
     default: {
       criteria satisfies never;
       throw new UnknownTypeError('getWinCriteriaName', criteria);

--- a/hera/ui/PlayerCard.tsx
+++ b/hera/ui/PlayerCard.tsx
@@ -4,6 +4,7 @@ import {
   destroyedBuildingsByPlayer,
   escortedByPlayer,
 } from '@deities/apollo/lib/checkWinCondition.tsx';
+import getCompletedObjectives from '@deities/apollo/lib/getCompletedObjectives.tsx';
 import { getSkillConfig, Skill } from '@deities/athena/info/Skill.tsx';
 import calculateFunds from '@deities/athena/lib/calculateFunds.tsx';
 import matchesPlayerList from '@deities/athena/lib/matchesPlayerList.tsx';
@@ -33,6 +34,7 @@ import Flag from '@iconify-icons/pixelarticons/flag.js';
 import Hourglass from '@iconify-icons/pixelarticons/hourglass.js';
 import HumanHandsdown from '@iconify-icons/pixelarticons/human-handsdown.js';
 import Escort from '@iconify-icons/pixelarticons/human-run.js';
+import List from '@iconify-icons/pixelarticons/list.js';
 import Reload from '@iconify-icons/pixelarticons/reload.js';
 import { memo, useCallback } from 'react';
 import activatePowerAction from '../behavior/activatePower/activatePowerAction.tsx';
@@ -374,7 +376,17 @@ const PlayerCardObjective = ({
               ]
             : condition.type === WinCriteria.Survival
               ? [Hourglass, map.round, condition.rounds]
-              : [null, null];
+              : condition.type === WinCriteria.OptionalObjectiveAmount
+                ? [
+                    List,
+                    getCompletedObjectives(map, player.id).filter(
+                      (conditionIndex) =>
+                        map.config.winConditions[conditionIndex].type !==
+                        WinCriteria.OptionalObjectiveAmount,
+                    ).length,
+                    condition.amount,
+                  ]
+                : [null, null];
 
   return (
     (icon && status != null && (

--- a/hera/win-conditions/WinConditionDescription.tsx
+++ b/hera/win-conditions/WinConditionDescription.tsx
@@ -262,6 +262,21 @@ const WinConditionText = ({
           </fbt:plural>.
         </fbt>
       );
+    case WinCriteria.OptionalObjectiveAmount:
+      return (
+        <fbt desc="Explanation for the complete optional objectives by amount win condition with multiple players">
+          <fbt:param name="players">{playerList}</fbt:param> can achieve the
+          objective by completing{' '}
+          <fbt:param name="amount">{condition.amount}</fbt:param>{' '}
+          <fbt:plural
+            count={condition.amount}
+            many="optional objectives"
+            name="number of optional objectives"
+          >
+            optional objective
+          </fbt:plural>.
+        </fbt>
+      );
     default: {
       condition satisfies never;
       throw new UnknownTypeError('WinConditionText', type);

--- a/tests/__tests__/Effects.test.tsx
+++ b/tests/__tests__/Effects.test.tsx
@@ -565,7 +565,7 @@ test('only one game end win effect is fired', () => {
       "Capture (1,1) { building: Barracks { id: 12, health: 100, player: 1 }, player: 2 }
       SetViewer
       CharacterMessage { message: 'Yay', player: 'self', unitId: 5, variant: 1 }
-      GameEnd { condition: { amount: 1, completed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 2 }, conditionId: 1, toPlayer: 1 }"
+      GameEnd { condition: { amount: 1, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 2 }, conditionId: 1, toPlayer: 1 }"
     `);
 });
 

--- a/tests/__tests__/Objective.test.tsx
+++ b/tests/__tests__/Objective.test.tsx
@@ -400,7 +400,7 @@ test('lose game if you destroy the last unit of the opponent but miss your own w
 
   expect(snapshotEncodedActionResponse(gameActionResponse))
     .toMatchInlineSnapshot(`
-      "AttackBuilding (1,1 → 2,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 5 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: 2000 }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 1 }, conditionId: 1, toPlayer: 2 }"
+      "AttackBuilding (1,1 → 2,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 5 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: 2166 }
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 1 }, conditionId: 1, toPlayer: 2 }"
     `);
 });

--- a/tests/__tests__/Objective.test.tsx
+++ b/tests/__tests__/Objective.test.tsx
@@ -400,7 +400,7 @@ test('lose game if you destroy the last unit of the opponent but miss your own w
 
   expect(snapshotEncodedActionResponse(gameActionResponse))
     .toMatchInlineSnapshot(`
-      "AttackBuilding (1,1 → 2,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 5 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: 2166 }
+      "AttackBuilding (1,1 → 2,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 5 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: 2000 }
       GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 1 }, conditionId: 1, toPlayer: 2 }"
     `);
 });

--- a/tests/__tests__/Unit.test.tsx
+++ b/tests/__tests__/Unit.test.tsx
@@ -312,7 +312,7 @@ test('escort radius with label', async () => {
     .toMatchInlineSnapshot(`
       "Move (1,1 → 2,3) { fuel: 37, completed: false, path: [2,1 → 2,2 → 2,3] }
       Move (2,2 → 3,1) { fuel: 38, completed: false, path: [2,1 → 3,1] }
-      GameEnd { condition: { amount: 1, completed: Set(0) {}, hidden: false, label: [ 2 ], optional: false, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { amount: 1, completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 2 ], optional: false, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const screenshot = await captureOne(initialMap, '1');

--- a/tests/__tests__/WinConditions.test.tsx
+++ b/tests/__tests__/WinConditions.test.tsx
@@ -580,8 +580,8 @@ test('destroy amount win criteria', async () => {
 
   expect(snapshotEncodedActionResponse(gameActionResponseB))
     .toMatchInlineSnapshot(`
-      "AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
-      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2732, chargeC: null }
+      "AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
+      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
       GameEnd { condition: { amount: 2, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 12 }, conditionId: 0, toPlayer: 1 }"
     `);
 
@@ -626,12 +626,12 @@ test('destroy amount win criteria', async () => {
 
   expect(snapshotEncodedActionResponse(gameActionResponseB_2))
     .toMatchInlineSnapshot(`
-      "AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
-      AttackBuilding (2,4 → 1,4) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2732, chargeC: null }
+      "AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
+      AttackBuilding (2,4 → 1,4) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
       OptionalObjective { condition: { amount: 2, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 12 }, conditionId: 0, toPlayer: 1 }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
-      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
-      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2732, chargeC: null }
+      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
+      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
       OptionalObjective { condition: { amount: 2, completed: Set(2) { 1, 2 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 12 }, conditionId: 0, toPlayer: 2 }"
     `);
 
@@ -666,7 +666,7 @@ test('destroy amount win criteria', async () => {
       "AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
       AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
-      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
+      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
       GameEnd { condition: { amount: 1, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [ 2 ], reward: null, type: 12 }, conditionId: 0, toPlayer: 2 }"
     `);
 
@@ -691,7 +691,7 @@ test('destroy amount win criteria', async () => {
       "AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
       AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
-      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
+      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
       OptionalObjective { condition: { amount: 1, completed: Set(1) { 2 }, failed: Set(0) {}, hidden: false, optional: true, players: [ 2 ], reward: null, type: 12 }, conditionId: 0, toPlayer: 2 }"
     `);
 
@@ -742,10 +742,10 @@ test('destroy label win criteria', async () => {
 
   expect(snapshotEncodedActionResponse(gameActionResponseA))
     .toMatchInlineSnapshot(`
-      "AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
-      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2732, chargeC: null }
-      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 4098, chargeC: null }
-      AttackBuilding (4,1 → 3,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 5464, chargeC: null }
+      "AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
+      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
+      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 3600, chargeC: null }
+      AttackBuilding (4,1 → 3,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 4800, chargeC: null }
       GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 4, 3 ], optional: false, players: [], reward: null, type: 11 }, conditionId: 0, toPlayer: 1 }"
     `);
 
@@ -765,10 +765,10 @@ test('destroy label win criteria', async () => {
 
   expect(snapshotEncodedActionResponse(gameActionResponseB))
     .toMatchInlineSnapshot(`
-      "AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
-      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2732, chargeC: null }
-      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 4098, chargeC: null }
-      AttackBuilding (4,1 → 3,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 5464, chargeC: null }
+      "AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
+      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
+      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 3600, chargeC: null }
+      AttackBuilding (4,1 → 3,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 4800, chargeC: null }
       OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 4, 3 ], optional: true, players: [], reward: null, type: 11 }, conditionId: 0, toPlayer: 1 }"
     `);
 
@@ -2625,7 +2625,7 @@ test('rescue label win criteria loses when destroying the rescuable unit', async
     .toMatchInlineSnapshot(`
       "Rescue (1,2 → 1,3) { player: 1 }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
-      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: 1 }
+      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: 1 }
       GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: false, players: [ 1 ], reward: null, type: 8 }, conditionId: 0, toPlayer: 2 }"
     `);
 

--- a/tests/__tests__/WinConditions.test.tsx
+++ b/tests/__tests__/WinConditions.test.tsx
@@ -161,7 +161,7 @@ test('capture amount win criteria', async () => {
       "Capture (1,2) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
       Capture (1,3) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
       Capture (2,1) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
-      GameEnd { condition: { amount: 4, completed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 2 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { amount: 4, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 2 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(mapWithConditions);
@@ -177,7 +177,7 @@ test('capture amount win criteria', async () => {
       "Capture (1,2) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
       Capture (1,3) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
       Capture (2,1) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
-      OptionalObjective { condition: { amount: 4, completed: Set(1) { 1 }, hidden: false, optional: true, players: [], reward: null, type: 2 }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { amount: 4, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 2 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB_2)).toBe(false);
@@ -214,7 +214,7 @@ test('capture amount win criteria', async () => {
       Capture (2,1) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 700, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
       Capture (1,1) { building: House { id: 2, health: 100, player: 2 }, player: 1 }
-      GameEnd { condition: { amount: 1, completed: Set(0) {}, hidden: false, optional: false, players: [ 2 ], reward: null, type: 2 }, conditionId: 0, toPlayer: 2 }"
+      GameEnd { condition: { amount: 1, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [ 2 ], reward: null, type: 2 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   const mapWithAsymmetricalOptionalObjectives = optional(
@@ -243,7 +243,7 @@ test('capture amount win criteria', async () => {
       Capture (2,1) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 700, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
       Capture (1,1) { building: House { id: 2, health: 100, player: 2 }, player: 1 }
-      OptionalObjective { condition: { amount: 1, completed: Set(1) { 2 }, hidden: false, optional: true, players: [ 2 ], reward: null, type: 2 }, conditionId: 0, toPlayer: 2 }"
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 2 }, failed: Set(0) {}, hidden: false, optional: true, players: [ 2 ], reward: null, type: 2 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   expect(gameHasEnded(gameStateC_2)).toBe(false);
@@ -287,7 +287,7 @@ test('capture amount win criteria also works when creating buildings', async () 
       "Capture (1,1) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
       Capture (2,2) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
       CreateBuilding (3,1) { building: House { id: 2, health: 100, player: 1, completed: true } }
-      GameEnd { condition: { amount: 3, completed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 2 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { amount: 3, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 2 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -304,7 +304,7 @@ test('capture amount win criteria also works when creating buildings', async () 
       "Capture (1,1) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
       Capture (2,2) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
       CreateBuilding (3,1) { building: House { id: 2, health: 100, player: 1, completed: true } }
-      OptionalObjective { condition: { amount: 3, completed: Set(1) { 1 }, hidden: false, optional: true, players: [], reward: null, type: 2 }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { amount: 3, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 2 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -358,7 +358,7 @@ test('capture label win criteria', async () => {
       Capture (1,3) { building: House { id: 2, health: 100, player: 1, label: 4 }, player: 2 }
       Capture (2,1) { building: House { id: 2, health: 100, player: 1, label: 3 }, player: 2 }
       Capture (2,2) { building: House { id: 2, health: 100, player: 1, label: 4 }, player: 2 }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 4, 3 ], optional: false, players: [], reward: null, type: 1 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 4, 3 ], optional: false, players: [], reward: null, type: 1 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = initialMap.copy({
@@ -388,7 +388,7 @@ test('capture label win criteria', async () => {
       Capture (1,3) { building: House { id: 2, health: 100, player: 1, label: 4 }, player: 2 }
       Capture (2,1) { building: House { id: 2, health: 100, player: 1, label: 3 }, player: 2 }
       Capture (2,2) { building: House { id: 2, health: 100, player: 1, label: 4 }, player: 2 }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, label: [ 4, 3 ], optional: true, players: [], reward: null, type: 1 }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 4, 3 ], optional: true, players: [], reward: null, type: 1 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -427,7 +427,7 @@ test('capture label win criteria fails because building is destroyed', async () 
   ).toMatchInlineSnapshot(
     `
     "AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 9 ] ] }, unitC: null, chargeA: null, chargeB: null, chargeC: null }
-    GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 1 }, conditionId: 0, toPlayer: 2 }"
+    GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 1 }, conditionId: 0, toPlayer: 2 }"
   `,
   );
 
@@ -459,7 +459,7 @@ test('capture label win criteria fails because building is destroyed', async () 
     `
     "EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
     AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 9 ] ] }, unitC: null, chargeA: null, chargeB: null, chargeC: null }
-    GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 1 }, conditionId: 0, toPlayer: 2 }"
+    GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 1 }, conditionId: 0, toPlayer: 2 }"
   `,
   );
 
@@ -580,9 +580,9 @@ test('destroy amount win criteria', async () => {
 
   expect(snapshotEncodedActionResponse(gameActionResponseB))
     .toMatchInlineSnapshot(`
-      "AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
-      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
-      GameEnd { condition: { amount: 2, completed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 12 }, conditionId: 0, toPlayer: 1 }"
+      "AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
+      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2732, chargeC: null }
+      GameEnd { condition: { amount: 2, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 12 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = map.copy({
@@ -626,13 +626,13 @@ test('destroy amount win criteria', async () => {
 
   expect(snapshotEncodedActionResponse(gameActionResponseB_2))
     .toMatchInlineSnapshot(`
-      "AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
-      AttackBuilding (2,4 → 1,4) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
-      OptionalObjective { condition: { amount: 2, completed: Set(1) { 1 }, hidden: false, optional: true, players: [], reward: null, type: 12 }, conditionId: 0, toPlayer: 1 }
+      "AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
+      AttackBuilding (2,4 → 1,4) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2732, chargeC: null }
+      OptionalObjective { condition: { amount: 2, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 12 }, conditionId: 0, toPlayer: 1 }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
-      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
-      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
-      OptionalObjective { condition: { amount: 2, completed: Set(2) { 1, 2 }, hidden: false, optional: true, players: [], reward: null, type: 12 }, conditionId: 0, toPlayer: 2 }"
+      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
+      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2732, chargeC: null }
+      OptionalObjective { condition: { amount: 2, completed: Set(2) { 1, 2 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 12 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   expect(gameHasEnded(gameStateB_2)).toBe(false);
@@ -666,8 +666,8 @@ test('destroy amount win criteria', async () => {
       "AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
       AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
-      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
-      GameEnd { condition: { amount: 1, completed: Set(0) {}, hidden: false, optional: false, players: [ 2 ], reward: null, type: 12 }, conditionId: 0, toPlayer: 2 }"
+      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
+      GameEnd { condition: { amount: 1, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [ 2 ], reward: null, type: 12 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   const mapWithAsymmetricOptionalObjectives = optional(
@@ -691,8 +691,8 @@ test('destroy amount win criteria', async () => {
       "AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
       AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
-      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
-      OptionalObjective { condition: { amount: 1, completed: Set(1) { 2 }, hidden: false, optional: true, players: [ 2 ], reward: null, type: 12 }, conditionId: 0, toPlayer: 2 }"
+      AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 2 }, failed: Set(0) {}, hidden: false, optional: true, players: [ 2 ], reward: null, type: 12 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   expect(gameHasEnded(gameStateC_2)).toBe(false);
@@ -742,11 +742,11 @@ test('destroy label win criteria', async () => {
 
   expect(snapshotEncodedActionResponse(gameActionResponseA))
     .toMatchInlineSnapshot(`
-      "AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
-      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
-      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 3600, chargeC: null }
-      AttackBuilding (4,1 → 3,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 4800, chargeC: null }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 4, 3 ], optional: false, players: [], reward: null, type: 11 }, conditionId: 0, toPlayer: 1 }"
+      "AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
+      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2732, chargeC: null }
+      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 4098, chargeC: null }
+      AttackBuilding (4,1 → 3,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 5464, chargeC: null }
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 4, 3 ], optional: false, players: [], reward: null, type: 11 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -765,11 +765,11 @@ test('destroy label win criteria', async () => {
 
   expect(snapshotEncodedActionResponse(gameActionResponseB))
     .toMatchInlineSnapshot(`
-      "AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
-      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2400, chargeC: null }
-      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 3600, chargeC: null }
-      AttackBuilding (4,1 → 3,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 4800, chargeC: null }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, label: [ 4, 3 ], optional: true, players: [], reward: null, type: 11 }, conditionId: 0, toPlayer: 1 }"
+      "AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: null }
+      AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 2732, chargeC: null }
+      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 4098, chargeC: null }
+      AttackBuilding (4,1 → 3,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 5464, chargeC: null }
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 4, 3 ], optional: true, players: [], reward: null, type: 11 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -867,7 +867,7 @@ test('destroy label win criteria (neutral structure)', async () => {
     .toMatchInlineSnapshot(`
       "AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
       AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: null, chargeC: null }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 3 ], optional: false, players: [], reward: null, type: 11 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 3 ], optional: false, players: [], reward: null, type: 11 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -886,7 +886,7 @@ test('destroy label win criteria (neutral structure)', async () => {
     .toMatchInlineSnapshot(`
       "AttackBuilding (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: null }
       AttackBuilding (2,1 → 1,1) { hasCounterAttack: false, playerA: 1, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 4 ] ] }, unitC: null, chargeA: null, chargeB: null, chargeC: null }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, label: [ 3 ], optional: true, players: [], reward: null, type: 11 }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 3 ], optional: true, players: [], reward: null, type: 11 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -935,7 +935,7 @@ test('defeat with label', async () => {
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
       AttackUnit (1,3 → 2,3) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 66, chargeB: 200 }
       AttackUnit (2,2 → 2,1) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 99, chargeB: 300 }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 4, 2 ], optional: false, players: [], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 4, 2 ], optional: false, players: [], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -956,7 +956,7 @@ test('defeat with label', async () => {
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
       AttackUnit (1,3 → 2,3) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 66, chargeB: 200 }
       AttackUnit (2,2 → 2,1) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 99, chargeB: 300 }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, label: [ 4, 2 ], optional: true, players: [], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 4, 2 ], optional: true, players: [], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -998,7 +998,7 @@ test('defeat one with label', async () => {
     .toMatchInlineSnapshot(`
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
       AttackUnit (2,2 → 2,1) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 66, chargeB: 200 }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 4, 2 ], optional: false, players: [], reward: null, type: 10 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 4, 2 ], optional: false, players: [], reward: null, type: 10 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1014,7 +1014,7 @@ test('defeat one with label', async () => {
     .toMatchInlineSnapshot(`
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
       AttackUnit (2,2 → 2,1) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 66, chargeB: 200 }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, label: [ 4, 2 ], optional: true, players: [], reward: null, type: 10 }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 4, 2 ], optional: true, players: [], reward: null, type: 10 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -1062,7 +1062,7 @@ test('defeat by amount', async () => {
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
       AttackUnit (1,3 → 2,3) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 66, chargeB: 200 }
       AttackUnit (2,2 → 2,1) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 99, chargeB: 300 }
-      GameEnd { condition: { amount: 3, completed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { amount: 3, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1083,7 +1083,7 @@ test('defeat by amount', async () => {
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
       AttackUnit (1,3 → 2,3) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 66, chargeB: 200 }
       AttackUnit (2,2 → 2,1) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 99, chargeB: 300 }
-      OptionalObjective { condition: { amount: 3, completed: Set(1) { 1 }, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { amount: 3, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -1119,7 +1119,7 @@ test('defeat by amount through counter attack', async () => {
   expect(snapshotEncodedActionResponse(gameActionResponseA))
     .toMatchInlineSnapshot(`
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: true, playerA: 1, playerB: 2, unitA: null, unitB: DryUnit { health: 56, ammo: [ [ 1, 3 ] ] }, chargeA: 62, chargeB: 176 }
-      GameEnd { condition: { amount: 1, completed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 2 }"
+      GameEnd { condition: { amount: 1, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1136,7 +1136,7 @@ test('defeat by amount through counter attack', async () => {
   ).toMatchInlineSnapshot(
     `
     "AttackUnit (1,1 → 1,2) { hasCounterAttack: true, playerA: 1, playerB: 2, unitA: null, unitB: DryUnit { health: 56, ammo: [ [ 1, 3 ] ] }, chargeA: 62, chargeB: 176 }
-    OptionalObjective { condition: { amount: 1, completed: Set(1) { 2 }, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 2 }"
+    OptionalObjective { condition: { amount: 1, completed: Set(1) { 2 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 2 }"
   `,
   );
 
@@ -1173,7 +1173,7 @@ test('defeat with label and Zombie', async () => {
   expect(snapshotEncodedActionResponse(gameActionResponseA))
     .toMatchInlineSnapshot(`
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: true, playerA: 1, playerB: 2, unitA: DryUnit { health: 48, ammo: [ [ 1, 4 ] ] }, unitB: DryUnit { health: 30, ammo: [ [ 1, 3 ] ] }, chargeA: 300, chargeB: 280 }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 2 ], optional: false, players: [], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 2 ], optional: false, players: [], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1188,7 +1188,7 @@ test('defeat with label and Zombie', async () => {
   expect(snapshotEncodedActionResponse(gameActionResponseB))
     .toMatchInlineSnapshot(`
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: true, playerA: 1, playerB: 2, unitA: DryUnit { health: 48, ammo: [ [ 1, 4 ] ] }, unitB: DryUnit { health: 30, ammo: [ [ 1, 3 ] ] }, chargeA: 300, chargeB: 280 }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, label: [ 2 ], optional: true, players: [], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 2 ], optional: true, players: [], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -1224,7 +1224,7 @@ test('defeat by amount and Zombie', async () => {
   expect(snapshotEncodedActionResponse(gameActionResponseA))
     .toMatchInlineSnapshot(`
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: true, playerA: 1, playerB: 2, unitA: DryUnit { health: 75, ammo: [ [ 1, 4 ] ] }, unitB: DryUnit { health: 35 }, chargeA: 142, chargeB: 130 }
-      GameEnd { condition: { amount: 1, completed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { amount: 1, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1239,7 +1239,7 @@ test('defeat by amount and Zombie', async () => {
   expect(snapshotEncodedActionResponse(gameActionResponseB))
     .toMatchInlineSnapshot(`
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: true, playerA: 1, playerB: 2, unitA: DryUnit { health: 75, ammo: [ [ 1, 4 ] ] }, unitB: DryUnit { health: 35 }, chargeA: 142, chargeB: 130 }
-      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -1350,7 +1350,7 @@ test('defeat with label and a unit hiding inside of another', async () => {
       AttackUnit (3,3 → 2,3) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
       AttackUnit (1,1 → 1,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitB: DryUnit { health: 20 }, chargeA: 72, chargeB: 220 }
       AttackUnit (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitB: null, chargeA: 81, chargeB: 250 }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 4, 2 ], optional: false, players: [ 1 ], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 4, 2 ], optional: false, players: [ 1 ], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1377,7 +1377,7 @@ test('defeat with label and a unit hiding inside of another', async () => {
       AttackUnit (3,3 → 2,3) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
       AttackUnit (1,1 → 1,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitB: DryUnit { health: 20 }, chargeA: 72, chargeB: 220 }
       AttackUnit (2,2 → 1,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitB: null, chargeA: 81, chargeB: 250 }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, label: [ 4, 2 ], optional: true, players: [ 1 ], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 4, 2 ], optional: true, players: [ 1 ], reward: null, type: 3 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -1419,7 +1419,7 @@ test('win by survival', async () => {
       EndTurn { current: { funds: 500, player: 2 }, next: { funds: 500, player: 1 }, round: 2, rotatePlayers: false, supply: null, miss: false }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 2, rotatePlayers: false, supply: null, miss: false }
       EndTurn { current: { funds: 500, player: 2 }, next: { funds: 500, player: 1 }, round: 3, rotatePlayers: false, supply: null, miss: false }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, optional: false, players: [ 1 ], reward: null, rounds: 3, type: 5 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [ 1 ], reward: null, rounds: 3, type: 5 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1443,7 +1443,7 @@ test('win by survival', async () => {
       EndTurn { current: { funds: 500, player: 2 }, next: { funds: 500, player: 1 }, round: 2, rotatePlayers: false, supply: null, miss: false }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 2, rotatePlayers: false, supply: null, miss: false }
       EndTurn { current: { funds: 500, player: 2 }, next: { funds: 500, player: 1 }, round: 3, rotatePlayers: false, supply: null, miss: false }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, optional: true, players: [ 1 ], reward: null, rounds: 3, type: 5 }, conditionId: 0, toPlayer: 1 }
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [ 1 ], reward: null, rounds: 3, type: 5 }, conditionId: 0, toPlayer: 1 }
       Move (1,1 → 2,1) { fuel: 29, completed: false, path: [2,1] }"
     `);
 
@@ -1497,7 +1497,7 @@ test('win by survival in one round', async () => {
   expect(snapshotEncodedActionResponse(gameActionResponseA))
     .toMatchInlineSnapshot(`
       "EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, optional: false, players: [ 2 ], reward: null, rounds: 1, type: 5 }, conditionId: 0, toPlayer: 2 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [ 2 ], reward: null, rounds: 1, type: 5 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1531,7 +1531,7 @@ test('win by survival in one round', async () => {
   expect(snapshotEncodedActionResponse(gameActionResponseB))
     .toMatchInlineSnapshot(`
       "EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
-      OptionalObjective { condition: { completed: Set(1) { 2 }, hidden: false, optional: true, players: [ 2 ], reward: null, rounds: 1, type: 5 }, conditionId: 0, toPlayer: 2 }"
+      OptionalObjective { condition: { completed: Set(1) { 2 }, failed: Set(0) {}, hidden: false, optional: true, players: [ 2 ], reward: null, rounds: 1, type: 5 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -1573,7 +1573,7 @@ test('escort units', async () => {
     .toMatchInlineSnapshot(`
       "Move (1,1 → 2,3) { fuel: 37, completed: false, path: [2,1 → 2,2 → 2,3] }
       Move (2,2 → 3,1) { fuel: 38, completed: false, path: [2,1 → 3,1] }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1589,7 +1589,7 @@ test('escort units', async () => {
     .toMatchInlineSnapshot(`
       "Move (1,1 → 2,3) { fuel: 37, completed: false, path: [2,1 → 2,2 → 2,3] }
       Move (2,2 → 3,1) { fuel: 38, completed: false, path: [2,1 → 3,1] }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, label: [ 1 ], optional: true, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: true, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -1689,7 +1689,7 @@ test('escort units (transport)', async () => {
       "Move (1,1 → 2,3) { fuel: 37, completed: false, path: [2,1 → 2,2 → 2,3] }
       Move (2,2 → 2,1) { fuel: 39, completed: false, path: [2,1] }
       Move (2,1 → 3,1) { fuel: 59, completed: false, path: [3,1] }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1706,7 +1706,7 @@ test('escort units (transport)', async () => {
       "Move (1,1 → 2,3) { fuel: 37, completed: false, path: [2,1 → 2,2 → 2,3] }
       Move (2,2 → 2,1) { fuel: 39, completed: false, path: [2,1] }
       Move (2,1 → 3,1) { fuel: 59, completed: false, path: [3,1] }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, label: [ 1 ], optional: true, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: true, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -1760,7 +1760,7 @@ test('escort units by drop (transport)', async () => {
       EndTurn { current: { funds: 500, player: 2 }, next: { funds: 500, player: 1 }, round: 2, rotatePlayers: false, supply: null, miss: false }
       Move (2,2 → 2,1) { fuel: 39, completed: false, path: [2,1] }
       DropUnit (2,1 → 3,1) { index: 0 }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1789,7 +1789,7 @@ test('escort units by drop (transport)', async () => {
       EndTurn { current: { funds: 500, player: 2 }, next: { funds: 500, player: 1 }, round: 2, rotatePlayers: false, supply: null, miss: false }
       Move (2,2 → 2,1) { fuel: 39, completed: false, path: [2,1] }
       DropUnit (2,1 → 3,1) { index: 0 }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, label: [ 1 ], optional: true, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: true, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -1839,7 +1839,7 @@ test('escort units by label fails', async () => {
       Move (2,2 → 2,1) { fuel: 39, completed: false, path: [2,1] }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
       AttackUnit (3,1 → 2,1) { hasCounterAttack: false, playerA: 2, playerB: 1, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 2 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 2 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1916,7 +1916,7 @@ test('escort units by label fails (transport)', async () => {
       AttackUnit (3,1 → 2,1) { hasCounterAttack: false, playerA: 2, playerB: 1, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitB: DryUnit { health: 20 }, chargeA: 39, chargeB: 120 }
       Move (1,3 → 2,2) { fuel: 28, completed: false, path: [1,2 → 2,2] }
       AttackUnit (2,2 → 2,1) { hasCounterAttack: false, playerA: 2, playerB: 1, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitB: null, chargeA: 48, chargeB: 150 }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 2 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 4, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 2 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -1984,7 +1984,7 @@ test('escort units by amount', async () => {
     .toMatchInlineSnapshot(`
       "Move (1,1 → 2,3) { fuel: 37, completed: false, path: [2,1 → 2,2 → 2,3] }
       Move (2,2 → 3,1) { fuel: 38, completed: false, path: [2,1 → 3,1] }
-      GameEnd { condition: { amount: 2, completed: Set(0) {}, hidden: false, label: [], optional: false, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { amount: 2, completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [], optional: false, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -2000,7 +2000,7 @@ test('escort units by amount', async () => {
     .toMatchInlineSnapshot(`
       "Move (1,1 → 2,3) { fuel: 37, completed: false, path: [2,1 → 2,2 → 2,3] }
       Move (2,2 → 3,1) { fuel: 38, completed: false, path: [2,1 → 3,1] }
-      OptionalObjective { condition: { amount: 2, completed: Set(1) { 1 }, hidden: false, label: [], optional: true, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { amount: 2, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [], optional: true, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -2065,7 +2065,7 @@ test('escort units by amount (label)', async () => {
     .toMatchInlineSnapshot(`
       "Move (1,1 → 2,3) { fuel: 37, completed: false, path: [2,1 → 2,2 → 2,3] }
       Move (2,2 → 3,1) { fuel: 38, completed: false, path: [2,1 → 3,1] }
-      GameEnd { condition: { amount: 1, completed: Set(0) {}, hidden: false, label: [ 2 ], optional: false, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { amount: 1, completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 2 ], optional: false, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = initialMap.copy({
@@ -2118,10 +2118,10 @@ test('escort units by amount (label)', async () => {
     .toMatchInlineSnapshot(`
       "Move (1,1 → 2,3) { fuel: 37, completed: false, path: [2,1 → 2,2 → 2,3] }
       Move (2,2 → 3,1) { fuel: 38, completed: false, path: [2,1 → 3,1] }
-      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, hidden: false, label: [ 2 ], optional: true, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 2 ], optional: true, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 1 }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
       Move (1,2 → 3,3) { fuel: 37, completed: false, path: [2,2 → 3,2 → 3,3] }
-      OptionalObjective { condition: { amount: 1, completed: Set(1) { 2 }, hidden: false, label: [ 1 ], optional: true, players: [ 2 ], reward: null, type: 6, vectors: [ '3,3', '3,2' ] }, conditionId: 1, toPlayer: 2 }"
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 2 }, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: true, players: [ 2 ], reward: null, type: 6, vectors: [ '3,3', '3,2' ] }, conditionId: 1, toPlayer: 2 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -2172,7 +2172,7 @@ test('escort units by amount with label fails', async () => {
       Move (2,2 → 2,1) { fuel: 39, completed: false, path: [2,1] }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
       AttackUnit (3,1 → 2,1) { hasCounterAttack: false, playerA: 2, playerB: 1, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
-      GameEnd { condition: { amount: 2, completed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 2 }"
+      GameEnd { condition: { amount: 2, completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 1 ], optional: false, players: [ 1 ], reward: null, type: 6, vectors: [ '3,1', '2,3' ] }, conditionId: 0, toPlayer: 2 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -2395,7 +2395,7 @@ test('rescue label win criteria', async () => {
       Rescue (1,2 → 1,1) { player: 1 }
       Rescue (2,3 → 1,3) { player: 1 }
       Rescue (2,1 → 2,2) { player: 1 }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: false, players: [], reward: null, type: 8 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: false, players: [], reward: null, type: 8 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -2426,7 +2426,7 @@ test('rescue label win criteria', async () => {
       Rescue (1,2 → 1,1) { player: 1 }
       Rescue (2,3 → 1,3) { player: 1 }
       Rescue (2,1 → 2,2) { player: 1 }
-      OptionalObjective { condition: { completed: Set(1) { 1 }, hidden: false, label: [ 0, 3 ], optional: true, players: [], reward: null, type: 8 }, conditionId: 0, toPlayer: 1 }"
+      OptionalObjective { condition: { completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: true, players: [], reward: null, type: 8 }, conditionId: 0, toPlayer: 1 }"
     `);
 
   expect(gameHasEnded(gameStateB)).toBe(false);
@@ -2473,7 +2473,7 @@ test('rescue label win criteria loses when destroying the rescuable unit', async
     .toMatchInlineSnapshot(`
       "Rescue (1,2 → 1,1) { player: 1 }
       AttackUnit (2,3 → 1,3) { hasCounterAttack: false, playerA: 1, playerB: 0, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitB: null, chargeA: 0, chargeB: null }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: false, players: [ 1 ], reward: null, type: 8 }, conditionId: 0, toPlayer: 2 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: false, players: [ 1 ], reward: null, type: 8 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   const mapWithOptionalObjectives = optional(initialMap);
@@ -2505,7 +2505,7 @@ test('rescue label win criteria loses when destroying the rescuable unit', async
       "Rescue (1,2 → 1,3) { player: 1 }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
       AttackUnit (2,3 → 1,3) { hasCounterAttack: false, playerA: 2, playerB: 0, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitB: null, chargeA: 0, chargeB: null }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: false, players: [ 1 ], reward: null, type: 8 }, conditionId: 0, toPlayer: 2 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: false, players: [ 1 ], reward: null, type: 8 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   const [gameStateB_2, gameActionResponseB_2] = executeGameActions(
@@ -2565,7 +2565,7 @@ test('rescue label win criteria loses when destroying the rescuable unit', async
       "Rescue (1,2 → 1,3) { player: 1 }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
       AttackUnit (2,3 → 1,3) { hasCounterAttack: false, playerA: 2, playerB: 0, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitB: null, chargeA: 0, chargeB: null }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: false, players: [ 1 ], reward: null, type: 8 }, conditionId: 0, toPlayer: 2 }"
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: false, players: [ 1 ], reward: null, type: 8 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   const [gameStateC_2, gameActionResponseC_2] = executeGameActions(
@@ -2625,8 +2625,8 @@ test('rescue label win criteria loses when destroying the rescuable unit', async
     .toMatchInlineSnapshot(`
       "Rescue (1,2 → 1,3) { player: 1 }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
-      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitC: null, chargeA: null, chargeB: 1200, chargeC: 1 }
-      GameEnd { condition: { completed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: false, players: [ 1 ], reward: null, type: 8 }, conditionId: 0, toPlayer: 2 }"
+      AttackBuilding (2,3 → 1,3) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 6 ] ] }, unitC: null, chargeA: null, chargeB: 1366, chargeC: 1 }
+      GameEnd { condition: { completed: Set(0) {}, failed: Set(0) {}, hidden: false, label: [ 0, 3 ], optional: false, players: [ 1 ], reward: null, type: 8 }, conditionId: 0, toPlayer: 2 }"
     `);
 
   const [gameStateD_2, gameActionResponseD_2] = executeGameActions(
@@ -2706,11 +2706,11 @@ test('optional objectives should not be triggered multiple times for the same pl
     .toMatchInlineSnapshot(`
       "AttackUnit (1,1 → 2,1) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 132, chargeB: 400 }
       AttackUnit (1,2 → 2,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 264, chargeB: 800 }
-      OptionalObjective { condition: { amount: 2, completed: Set(1) { 1 }, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }
+      OptionalObjective { condition: { amount: 2, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
       AttackUnit (2,3 → 1,3) { hasCounterAttack: false, playerA: 2, playerB: 1, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 932, chargeB: 664 }
       AttackUnit (2,4 → 1,4) { hasCounterAttack: false, playerA: 2, playerB: 1, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 1064, chargeB: 1064 }
-      OptionalObjective { condition: { amount: 2, completed: Set(2) { 1, 2 }, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 2 }
+      OptionalObjective { condition: { amount: 2, completed: Set(2) { 1, 2 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 2 }
       EndTurn { current: { funds: 500, player: 2 }, next: { funds: 500, player: 1 }, round: 2, rotatePlayers: false, supply: null, miss: false }
       Move (1,1 → 1,3) { fuel: 28, completed: false, path: [1,2 → 1,3] }
       AttackUnit (1,3 → 2,3) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 2 ] ] }, unitB: null, chargeA: 1196, chargeB: 1464 }
@@ -2778,17 +2778,17 @@ test('optional objectives should not end the game, but non-optional one should w
     .toMatchInlineSnapshot(`
       "AttackUnit (1,1 → 2,1) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 132, chargeB: 400 }
       AttackUnit (1,2 → 2,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 264, chargeB: 800 }
-      OptionalObjective { condition: { amount: 2, completed: Set(1) { 1 }, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 1, toPlayer: 1 }
+      OptionalObjective { condition: { amount: 2, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 1, toPlayer: 1 }
       EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
       AttackUnit (2,3 → 1,3) { hasCounterAttack: false, playerA: 2, playerB: 1, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 932, chargeB: 664 }
       AttackUnit (2,4 → 1,4) { hasCounterAttack: false, playerA: 2, playerB: 1, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 1064, chargeB: 1064 }
-      OptionalObjective { condition: { amount: 2, completed: Set(2) { 1, 2 }, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 1, toPlayer: 2 }
+      OptionalObjective { condition: { amount: 2, completed: Set(2) { 1, 2 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 1, toPlayer: 2 }
       EndTurn { current: { funds: 500, player: 2 }, next: { funds: 500, player: 1 }, round: 2, rotatePlayers: false, supply: null, miss: false }
       Move (1,1 → 1,3) { fuel: 28, completed: false, path: [1,2 → 1,3] }
       AttackUnit (1,3 → 2,3) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 2 ] ] }, unitB: null, chargeA: 1196, chargeB: 1464 }
       Move (1,2 → 1,4) { fuel: 28, completed: false, path: [1,3 → 1,4] }
       AttackUnit (1,4 → 2,4) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 2 ] ] }, unitB: null, chargeA: 1328, chargeB: 1864 }
-      GameEnd { condition: { amount: 4, completed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }"
+      GameEnd { condition: { amount: 4, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }"
     `);
 });
 
@@ -2849,9 +2849,346 @@ test('optional objectives are processed before game end responses', async () => 
     .toMatchInlineSnapshot(`
       "AttackUnit (1,1 → 1,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 132, chargeB: 400 }
       AttackUnitGameOver { fromPlayer: 2, toPlayer: 1 }
-      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, hidden: false, optional: true, players: [], reward: { skill: 12, type: 'skill' }, type: 9 }, conditionId: 1, toPlayer: 1 }
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: { skill: 12, type: 'skill' }, type: 9 }, conditionId: 1, toPlayer: 1 }
       CharacterMessage { message: 'FIRE!', player: 'self', unitId: 15, variant: 2 }
       ReceiveReward { player: 1, reward: 'Reward { skill: 12 }' }
       GameEnd { condition: null, conditionId: null, toPlayer: 1 }"
+    `);
+});
+
+test('optional objective amount should specify amount less than or equal to total number of optional objectives', async () => {
+  const v1 = vec(1, 1);
+  const v2 = vec(1, 2);
+  const invalidMap = map.copy({
+    config: map.config.copy({
+      winConditions: [
+        {
+          amount: 5,
+          hidden: false,
+          optional: true,
+          type: WinCriteria.DefeatAmount,
+        },
+        {
+          amount: 2,
+          hidden: false,
+          optional: true,
+          players: [1],
+          type: WinCriteria.EscortAmount,
+          vectors: new Set([v1, v2]),
+        },
+        {
+          amount: 4,
+          hidden: false,
+          optional: false,
+          type: WinCriteria.CaptureAmount,
+        },
+        {
+          amount: 3,
+          hidden: false,
+          optional: false,
+          type: WinCriteria.OptionalObjectiveAmount,
+        },
+      ],
+    }),
+  });
+
+  expect(validateWinConditions(invalidMap)).toBe(false);
+
+  const invalidMap2 = invalidMap.copy({
+    config: invalidMap.config.copy({
+      winConditions: [
+        ...invalidMap.config.winConditions.filter(
+          (condition) => condition.type !== WinCriteria.OptionalObjectiveAmount,
+        ),
+        {
+          amount: 0,
+          hidden: false,
+          optional: false,
+          type: WinCriteria.OptionalObjectiveAmount,
+        },
+      ],
+    }),
+  });
+
+  expect(validateWinConditions(invalidMap2)).toBe(false);
+
+  const validMap = map.copy({
+    config: map.config.copy({
+      winConditions: [
+        {
+          amount: 5,
+          hidden: false,
+          optional: true,
+          type: WinCriteria.DefeatAmount,
+        },
+        {
+          amount: 2,
+          hidden: false,
+          optional: true,
+          players: [1],
+          type: WinCriteria.EscortAmount,
+          vectors: new Set([v1, v2]),
+        },
+        {
+          amount: 4,
+          hidden: false,
+          optional: false,
+          type: WinCriteria.CaptureAmount,
+        },
+        {
+          amount: 2,
+          hidden: false,
+          optional: false,
+          type: WinCriteria.OptionalObjectiveAmount,
+        },
+      ],
+    }),
+  });
+
+  expect(validateWinConditions(validMap)).toBe(true);
+
+  const validMap2 = validMap.copy({
+    config: validMap.config.copy({
+      winConditions: [
+        ...validMap.config.winConditions.filter(
+          (condition) => condition.type !== WinCriteria.OptionalObjectiveAmount,
+        ),
+        {
+          amount: 1,
+          hidden: false,
+          optional: false,
+          type: WinCriteria.OptionalObjectiveAmount,
+        },
+      ],
+    }),
+  });
+
+  expect(validateWinConditions(validMap2)).toBe(true);
+});
+
+test('optional objective amount', async () => {
+  const v1 = vec(1, 1);
+  const v2 = vec(1, 2);
+  const v3 = vec(2, 1);
+  const v4 = vec(2, 2);
+  const initialMap = map.copy({
+    buildings: map.buildings
+      .set(v1, House.create(player1))
+      .set(v2, House.create(player2)),
+    config: map.config.copy({
+      winConditions: [
+        {
+          amount: 1,
+          hidden: false,
+          optional: true,
+          reward: {
+            skill: Skill.BuyUnitBazookaBear,
+            type: 'skill',
+          },
+          type: WinCriteria.DefeatAmount,
+        },
+        {
+          amount: 1,
+          hidden: false,
+          optional: true,
+          type: WinCriteria.CaptureAmount,
+        },
+        {
+          amount: 2,
+          hidden: false,
+          optional: false,
+          type: WinCriteria.OptionalObjectiveAmount,
+        },
+      ],
+    }),
+    units: map.units
+      .set(v2, Pioneer.create(player1).capture())
+      .set(v3, Flamethrower.create(player1))
+      .set(v4, Pioneer.create(player2)),
+  });
+
+  expect(validateWinConditions(initialMap)).toBe(true);
+
+  const [, gameActionResponse] = executeGameActions(initialMap, [
+    CaptureAction(v2),
+    AttackUnitAction(v3, v4),
+  ]);
+
+  expect(snapshotEncodedActionResponse(gameActionResponse))
+    .toMatchInlineSnapshot(`
+      "Capture (1,2) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 2 }, conditionId: 1, toPlayer: 1 }
+      AttackUnit (2,1 → 2,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: { skill: 12, type: 'skill' }, type: 9 }, conditionId: 0, toPlayer: 1 }
+      ReceiveReward { player: 1, reward: 'Reward { skill: 12 }' }
+      GameEnd { condition: { amount: 2, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [], reward: null, type: 13 }, conditionId: 2, toPlayer: 1 }"
+    `);
+});
+
+test('optional objective amount (optional)', async () => {
+  const v1 = vec(1, 1);
+  const v2 = vec(1, 2);
+  const v3 = vec(2, 1);
+  const v4 = vec(2, 2);
+  const initialMap = map.copy({
+    buildings: map.buildings
+      .set(v1, House.create(player1))
+      .set(v2, House.create(player2)),
+    config: map.config.copy({
+      winConditions: [
+        {
+          amount: 1,
+          hidden: false,
+          optional: true,
+          type: WinCriteria.DefeatAmount,
+        },
+        {
+          amount: 1,
+          hidden: false,
+          optional: true,
+          type: WinCriteria.CaptureAmount,
+        },
+        {
+          amount: 2,
+          hidden: false,
+          optional: true,
+          type: WinCriteria.OptionalObjectiveAmount,
+        },
+        { hidden: false, type: WinCriteria.Default },
+      ],
+    }),
+    units: map.units
+      .set(v1, Pioneer.create(player2))
+      .set(v2, Pioneer.create(player1).capture())
+      .set(v3, Flamethrower.create(player1))
+      .set(v4, Pioneer.create(player2)),
+  });
+
+  expect(validateWinConditions(initialMap)).toBe(true);
+
+  const [, gameActionResponse] = executeGameActions(initialMap, [
+    CaptureAction(v2),
+    AttackUnitAction(v3, v4),
+  ]);
+
+  expect(snapshotEncodedActionResponse(gameActionResponse))
+    .toMatchInlineSnapshot(`
+      "Capture (1,2) { building: House { id: 2, health: 100, player: 1 }, player: 2 }
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 2 }, conditionId: 1, toPlayer: 1 }
+      AttackUnit (2,1 → 2,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }
+      OptionalObjective { condition: { amount: 2, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [], reward: null, type: 13 }, conditionId: 2, toPlayer: 1 }"
+    `);
+});
+
+test('optional objective amount fails when one of the target objectives is no longer achievable', async () => {
+  const v1 = vec(1, 1);
+  const v2 = vec(1, 2);
+  const v3 = vec(2, 1);
+  const v4 = vec(2, 2);
+  const initialMap = map.copy({
+    buildings: map.buildings.set(
+      v1,
+      House.create(0, { label: 1 }).setHealth(1),
+    ),
+    config: map.config.copy({
+      winConditions: [
+        {
+          amount: 1,
+          hidden: false,
+          optional: true,
+          players: [1],
+          type: WinCriteria.DefeatAmount,
+        },
+        {
+          hidden: false,
+          label: new Set([1]),
+          optional: true,
+          players: [1],
+          type: WinCriteria.CaptureLabel,
+        },
+        {
+          amount: 2,
+          hidden: false,
+          optional: false,
+          players: [1],
+          type: WinCriteria.OptionalObjectiveAmount,
+        },
+      ],
+    }),
+    units: map.units
+      .set(v2, HeavyTank.create(player2))
+      .set(v3, Flamethrower.create(player1))
+      .set(v4, Pioneer.create(player2)),
+  });
+
+  expect(validateWinConditions(initialMap)).toBe(true);
+
+  const [, gameActionResponseA] = executeGameActions(initialMap, [
+    AttackUnitAction(v3, v4),
+    EndTurnAction(),
+    AttackBuildingAction(v2, v1),
+  ]);
+
+  expect(snapshotEncodedActionResponse(gameActionResponseA))
+    .toMatchInlineSnapshot(`
+      "AttackUnit (2,1 → 2,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [ 1 ], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }
+      EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
+      AttackBuilding (1,2 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 9 ] ] }, unitC: null, chargeA: null, chargeB: null, chargeC: null }
+      DeniedOptionalObjective { condition: { completed: Set(0) {}, failed: Set(1) { 1 }, hidden: false, label: [ 1 ], optional: true, players: [ 1 ], reward: null, type: 1 }, conditionId: 1 }
+      GameEnd { condition: { amount: 2, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [ 1 ], reward: null, type: 13 }, conditionId: 2, toPlayer: 2 }"
+    `);
+
+  const mapWithOptionalObjectives = optional(initialMap);
+
+  expect(validateWinConditions(mapWithOptionalObjectives)).toBe(true);
+
+  const [, gameActionResponseB] = executeGameActions(
+    mapWithOptionalObjectives,
+    [AttackUnitAction(v3, v4), EndTurnAction(), AttackBuildingAction(v2, v1)],
+  );
+
+  expect(snapshotEncodedActionResponse(gameActionResponseB))
+    .toMatchInlineSnapshot(`
+    "AttackUnit (2,1 → 2,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
+    OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [ 1 ], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }
+    EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
+    AttackBuilding (1,2 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 9 ] ] }, unitC: null, chargeA: null, chargeB: null, chargeC: null }"
+  `);
+
+  const mapWithMultipleOptionalObjectiveAmount = initialMap.copy({
+    config: initialMap.config.copy({
+      winConditions: [
+        ...initialMap.config.winConditions,
+        {
+          amount: 1,
+          hidden: false,
+          optional: true,
+          players: [1],
+          type: WinCriteria.OptionalObjectiveAmount,
+        },
+      ],
+    }),
+  });
+
+  expect(validateWinConditions(mapWithMultipleOptionalObjectiveAmount)).toBe(
+    true,
+  );
+
+  const [, gameActionResponseC] = executeGameActions(
+    mapWithMultipleOptionalObjectiveAmount,
+    [AttackUnitAction(v3, v4), EndTurnAction(), AttackBuildingAction(v2, v1)],
+  );
+
+  expect(snapshotEncodedActionResponse(gameActionResponseC))
+    .toMatchInlineSnapshot(`
+      "AttackUnit (2,1 → 2,2) { hasCounterAttack: false, playerA: 1, playerB: 2, unitA: DryUnit { health: 100, ammo: [ [ 1, 3 ] ] }, unitB: null, chargeA: 33, chargeB: 100 }
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [ 1 ], reward: null, type: 9 }, conditionId: 0, toPlayer: 1 }
+      OptionalObjective { condition: { amount: 1, completed: Set(1) { 1 }, failed: Set(0) {}, hidden: false, optional: true, players: [ 1 ], reward: null, type: 13 }, conditionId: 3, toPlayer: 1 }
+      EndTurn { current: { funds: 500, player: 1 }, next: { funds: 500, player: 2 }, round: 1, rotatePlayers: false, supply: null, miss: false }
+      AttackBuilding (1,2 → 1,1) { hasCounterAttack: false, playerA: 2, building: null, playerC: null, unitA: DryUnit { health: 100, ammo: [ [ 1, 9 ] ] }, unitC: null, chargeA: null, chargeB: null, chargeC: null }
+      DeniedOptionalObjective { condition: { completed: Set(0) {}, failed: Set(1) { 1 }, hidden: false, label: [ 1 ], optional: true, players: [ 1 ], reward: null, type: 1 }, conditionId: 1 }
+      GameEnd { condition: { amount: 2, completed: Set(0) {}, failed: Set(0) {}, hidden: false, optional: false, players: [ 1 ], reward: null, type: 13 }, conditionId: 2, toPlayer: 2 }"
     `);
 });


### PR DESCRIPTION
This PR is my attempt at #35.

The implementation kinda got bloated to cover the case where optional objective amount fails due to one of the target objectives is no longer achievable as discussed extensively in #35 with @cpojer.

I feel like there are still a lot of rough edges to be ironed out in the PR, but thought it'd be better to share the work early than to keep pulling my hair out, thinking about some potential edge cases by myself.