### PR TITLE
Implement Medics and Support Ships healing nearby units

### DIFF
--- a/athena/Objectives.tsx
+++ b/athena/Objectives.tsx
@@ -716,6 +716,33 @@ export function getOpponentPriorityLabels(objectives: Objectives, player: Player
   return labels;
 }
 
+export function getSelfPriorityLabels(objectives: Objectives, player: PlayerID) {
+  const labels = new Set<PlayerID>();
+  for (const [, objective] of objectives) {
+    if (!objectiveHasLabel(objective) || !objective.label?.size) {
+      continue;
+    }
+
+    const { label, players, type } = objective;
+    if (
+      ((type === Criteria.EscortAmount ||
+        type === Criteria.EscortLabel ||
+        type === Criteria.RescueLabel) &&
+        (!players?.length || players.includes(player))) ||
+      ((type === Criteria.DefeatLabel ||
+        type === Criteria.DestroyLabel ||
+        type === Criteria.DefeatOneLabel) &&
+        players?.length &&
+        !players.includes(player))
+    ) {
+      for (const player of label) {
+        labels.add(player);
+      }
+    }
+  }
+  return labels;
+}
+
 const validateLabel = (label: PlayerIDSet) => {
   if (!label.size) {
     return false;

--- a/dionysus/DionysusAlpha.tsx
+++ b/dionysus/DionysusAlpha.tsx
@@ -10,6 +10,7 @@ import {
   CreateUnitAction,
   DropUnitAction,
   FoldAction,
+  HealAction,
   MoveAction,
   RescueAction,
   SabotageAction,
@@ -45,7 +46,7 @@ import hasUnitsOrProductionBuildings from '@deities/athena/lib/hasUnitsOrProduct
 import needsSupply from '@deities/athena/lib/needsSupply.tsx';
 import { AIBehavior } from '@deities/athena/map/AIBehavior.tsx';
 import Building from '@deities/athena/map/Building.tsx';
-import { Charge } from '@deities/athena/map/Configuration.tsx';
+import { Charge, MaxHealth } from '@deities/athena/map/Configuration.tsx';
 import { EntityType, getEntityGroup, getEntityInfoGroup } from '@deities/athena/map/Entity.tsx';
 import Player, { PlayerID } from '@deities/athena/map/Player.tsx';
 import Unit from '@deities/athena/map/Unit.tsx';
@@ -63,6 +64,7 @@ import estimateClosestTarget from './lib/estimateClosestTarget.tsx';
 import findPathToTarget from './lib/findPathToTarget.tsx';
 import getAttackableUnitsWithinRadius from './lib/getAttackableUnitsWithinRadius.tsx';
 import getBuildingWeight from './lib/getBuildingWeight.tsx';
+import getHealingWeight from './lib/getHealingWeight.tsx';
 import getInterestingVectors from './lib/getInterestingVectors.tsx';
 import getInterestingVectorsByAbilities from './lib/getInterestingVectorsByAbilities.tsx';
 import getPossibleAttacks from './lib/getPossibleAttacks.tsx';
@@ -90,6 +92,7 @@ export default class DionysusAlpha extends BaseAI {
       this.finishRescue(map) ||
       this.toggleLightning(map) ||
       this.rescue(map) ||
+      this.healUnit(map) ||
       this.attack(map) ||
       this.capture(map) ||
       this.fold(map) ||
@@ -1176,6 +1179,71 @@ export default class DionysusAlpha extends BaseAI {
     }
 
     return this.execute(map, CompleteBuildingAction(from));
+  }
+
+  private healUnit(map: MapData): MapData | null {
+    const currentPlayer = map.getCurrentPlayer();
+    const entry = map.units.findEntry(
+      (unit) =>
+        !unit.isCompleted() &&
+        unit.info.hasAbility(Ability.Heal) &&
+        map.matchesPlayer(currentPlayer, unit),
+    );
+
+    if (!entry) {
+      return null;
+    }
+
+    const [from, unit] = entry;
+    const { parent, to } =
+      (shouldMove(unit) &&
+        maxBy(
+          [...moveable(this.applyVision(map), unit, from, undefined, undefined, true)].flatMap(
+            ([, { cost, vector }]) => {
+              const vectors: Array<Readonly<{ parent: Vector; to: Vector; weight: number }>> = [];
+              if (vector.equals(from) || !map.units.has(vector)) {
+                for (const adjacent of vector.adjacent()) {
+                  const targetUnit = map.units.get(adjacent);
+                  const healingWeight = targetUnit && getHealingWeight(map, targetUnit);
+                  const validVector =
+                    healingWeight &&
+                    map.matchesPlayer(unit, targetUnit) &&
+                    targetUnit.health < MaxHealth &&
+                    unit.info.configuration.healTypes?.has(targetUnit.info.type);
+                  if (validVector) {
+                    vectors.push({
+                      parent: vector,
+                      to: adjacent,
+                      weight: healingWeight * 10 - cost,
+                    });
+                  }
+                }
+              }
+              return vectors;
+            },
+          ),
+          (item) => item?.weight || Number.NEGATIVE_INFINITY,
+        )) ||
+      {};
+
+    if (!to || !parent) {
+      return null;
+    }
+
+    if (parent.equals(from)) {
+      return this.execute(map, HealAction(parent, to));
+    }
+
+    const [currentMap, isBlocked] = this.executeMove(map, MoveAction(from, parent));
+    if (isBlocked) {
+      return currentMap;
+    }
+
+    if (!currentMap) {
+      throw new Error('Error executing unit move.');
+    }
+
+    return this.execute(currentMap, HealAction(parent, to));
   }
 }
 

--- a/dionysus/lib/getHealingWeight.tsx
+++ b/dionysus/lib/getHealingWeight.tsx
@@ -1,35 +1,34 @@
-import { MinFunds } from '@deities/athena/info/Building.tsx';
 import getHealCost from '@deities/athena/lib/getHealCost.tsx';
 import Unit from '@deities/athena/map/Unit.tsx';
 import MapData from '@deities/athena/MapData.tsx';
+import { getSelfPriorityLabels } from '@deities/athena/Objectives.tsx';
 
 export default function getHealingWeight(map: MapData, unit: Unit) {
-  const { info } = unit;
   const currentPlayer = map.getCurrentPlayer();
   const injuryFactor = Math.pow((100 - unit.health) / 100, 2);
   const healCost = getHealCost(unit, currentPlayer);
+  const labelsToPrioritize = getSelfPriorityLabels(map.config.objectives, currentPlayer.id);
 
-  if (healCost > currentPlayer.funds / 2) {
+  if (healCost > currentPlayer.funds / 2 && currentPlayer.funds - healCost > 100) {
     return undefined;
   }
 
-  let weight =
-    ((info.getCostFor(currentPlayer) / MinFunds + info.defense) * injuryFactor) / (healCost + 1);
+  let weight = (unit.info.getCostFor(currentPlayer) * injuryFactor) / (healCost + 1);
+
+  if (unit.label && labelsToPrioritize.has(unit.label)) {
+    weight *= 100;
+  }
 
   if (unit.isCapturing()) {
     weight *= 5;
   }
 
   if (unit.isTransportingUnits()) {
-    weight *= 2;
-  }
-
-  if (unit.label !== null) {
-    weight *= 1.2;
+    weight *= 3;
   }
 
   if (unit.isLeader()) {
-    weight *= 1.1;
+    weight *= 2;
   }
 
   if (!unit.hasFuel() || unit.isOutOfAmmo()) {

--- a/dionysus/lib/getHealingWeight.tsx
+++ b/dionysus/lib/getHealingWeight.tsx
@@ -1,3 +1,7 @@
+import { MinFunds } from '@deities/athena/info/Building.tsx';
+import calculateFunds, {
+  calculateTotalPossibleFunds,
+} from '@deities/athena/lib/calculateFunds.tsx';
 import getHealCost from '@deities/athena/lib/getHealCost.tsx';
 import Unit from '@deities/athena/map/Unit.tsx';
 import MapData from '@deities/athena/MapData.tsx';
@@ -5,11 +9,15 @@ import { getSelfPriorityLabels } from '@deities/athena/Objectives.tsx';
 
 export default function getHealingWeight(map: MapData, unit: Unit) {
   const currentPlayer = map.getCurrentPlayer();
-  const injuryFactor = Math.pow((100 - unit.health) / 100, 2);
-  const healCost = getHealCost(unit, currentPlayer);
   const labelsToPrioritize = getSelfPriorityLabels(map.config.objectives, currentPlayer.id);
 
-  if (healCost > currentPlayer.funds / 2 && currentPlayer.funds - healCost > 100) {
+  const injuryFactor = Math.pow((100 - unit.health) / 100, 2);
+  const healCost = getHealCost(unit, currentPlayer);
+  const playerIncome = calculateFunds(map, currentPlayer);
+  const maxMapIncome = calculateTotalPossibleFunds(map);
+  const minSavings = playerIncome > 0 ? MinFunds * 2 : maxMapIncome > 0 ? MinFunds * 4 : MinFunds;
+
+  if (currentPlayer.funds - healCost <= minSavings) {
     return undefined;
   }
 

--- a/dionysus/lib/getHealingWeight.tsx
+++ b/dionysus/lib/getHealingWeight.tsx
@@ -1,0 +1,40 @@
+import { MinFunds } from '@deities/athena/info/Building.tsx';
+import getHealCost from '@deities/athena/lib/getHealCost.tsx';
+import Unit from '@deities/athena/map/Unit.tsx';
+import MapData from '@deities/athena/MapData.tsx';
+
+export default function getHealingWeight(map: MapData, unit: Unit) {
+  const { info } = unit;
+  const currentPlayer = map.getCurrentPlayer();
+  const injuryFactor = Math.pow((100 - unit.health) / 100, 2);
+  const healCost = getHealCost(unit, currentPlayer);
+
+  if (healCost > currentPlayer.funds / 2) {
+    return undefined;
+  }
+
+  let weight =
+    ((info.getCostFor(currentPlayer) / MinFunds + info.defense) * injuryFactor) / (healCost + 1);
+
+  if (unit.isCapturing()) {
+    weight *= 5;
+  }
+
+  if (unit.isTransportingUnits()) {
+    weight *= 2;
+  }
+
+  if (unit.label !== null) {
+    weight *= 1.2;
+  }
+
+  if (unit.isLeader()) {
+    weight *= 1.1;
+  }
+
+  if (!unit.hasFuel() || unit.isOutOfAmmo()) {
+    weight *= 0.8;
+  }
+
+  return weight;
+}

--- a/tests/__tests__/AIBehavior.test.tsx
+++ b/tests/__tests__/AIBehavior.test.tsx
@@ -14,6 +14,7 @@ import {
 import { getSkillConfig, Skill } from '@deities/athena/info/Skill.tsx';
 import {
   Airfield,
+  Beach,
   ConstructionSite,
   Forest,
   Plain,
@@ -30,14 +31,17 @@ import {
   Flamethrower,
   HeavyArtillery,
   HeavyTank,
+  Hovercraft,
   Humvee,
   Infantry,
   Jetpack,
+  Medic,
   Pioneer,
   Saboteur,
   SmallTank,
   Sniper,
   SuperTank,
+  SupportShip,
   TransportHelicopter,
   XFighter,
   Zombie,
@@ -1184,5 +1188,147 @@ test('creates production buildings in the space biome despite not having access 
     CreateBuilding (5,5) { building: Spawn Platform { id: 19, health: 100, player: 2, completed: true }, free: null }
     CompleteUnit (5,3)
     EndTurn { current: { funds: 850, player: 2 }, next: { funds: 0, player: 1 }, round: 2, rotatePlayers: null, supply: null, miss: null }"
+  `);
+});
+
+test('AI will prioritize healing own units with labels associated with objectives', async () => {
+  const map = initialMap.copy({
+    config: initialMap.config.copy({
+      objectives: ImmutableMap([
+        [0, { hidden: false, type: Criteria.Default }],
+        [
+          1,
+          {
+            hidden: false,
+            label: new Set([1]),
+            optional: false,
+            players: [2],
+            reward: null,
+            type: Criteria.EscortLabel,
+            vectors: new Set([vec(3, 1)]),
+          },
+        ],
+      ]),
+    }),
+    units: initialMap.units
+      .set(vec(1, 2), FighterJet.create(1))
+      .set(vec(2, 1), Infantry.create(2).setHealth(50))
+      .set(vec(2, 3), Infantry.create(2, { label: 1 }).setHealth(50))
+      .set(vec(3, 2), Medic.create(2)),
+  });
+
+  const [, , gameStateA] = await executeGameAction(
+    map,
+    map.createVisionObject(player1),
+    new Map(),
+    EndTurnAction(),
+    AIRegistry,
+  );
+
+  expect(snapshotGameState(gameStateA)).toMatchInlineSnapshot(`
+    "Move (3,2 → 3,3) { fuel: 79, completed: null, path: [3,3] }
+    Heal (3,3 → 2,3)
+    Move (2,1 → 1,1) { fuel: 49, completed: null, path: [1,1] }
+    Move (2,3 → 3,1) { fuel: 47, completed: null, path: [2,2 → 2,1 → 3,1] }
+    GameEnd { objective: { hidden: false, label: [ 1 ], optional: false, players: [ 2 ], reward: null, type: 4, vectors: [ '3,1' ] }, objectiveId: 1, toPlayer: 2, chaosStars: null }"
+  `);
+});
+
+test('AI will prioritize healing own units currently transporting other units', async () => {
+  const tileMap = Array(3 * 3).fill(Sea.id);
+  tileMap[3] = Plain.id;
+  tileMap[6] = Beach.id;
+
+  const map = withModifiers(
+    initialMap.copy({
+      config: initialMap.config.copy({ fog: false }),
+      map: tileMap,
+      units: initialMap.units
+        .set(vec(1, 1), Hovercraft.create(2).setHealth(50))
+        .set(vec(1, 2), Infantry.create(2))
+        .set(vec(1, 3), Hovercraft.create(2).setHealth(80))
+        .set(vec(2, 2), SupportShip.create(2))
+        .set(vec(3, 1), Hovercraft.create(2).setHealth(50))
+        .set(vec(3, 3), FighterJet.create(1)),
+    }),
+  );
+
+  const [, , gameStateA] = await executeGameAction(
+    map,
+    map.createVisionObject(player1),
+    new Map(),
+    EndTurnAction(),
+    AIRegistry,
+  );
+
+  expect(snapshotGameState(gameStateA)).toMatchInlineSnapshot(`
+    "Move (2,2 → 2,1) { fuel: 88, completed: null, path: [2,1] }
+    Heal (2,1 → 3,1)
+    Move (1,2 → 1,3) { fuel: 49, completed: null, path: [1,3] }
+    CompleteUnit (1,1)
+    CompleteUnit (3,1)
+    CompleteUnit (1,3)
+    EndTurn { current: { funds: 840, player: 2 }, next: { funds: 0, player: 1 }, round: 2, rotatePlayers: null, supply: null, miss: null }"
+  `);
+
+  const lastMapA = gameStateA!.at(-1)![1];
+  const [, , gameStateB] = await executeGameAction(
+    lastMapA,
+    map.createVisionObject(player1),
+    new Map(),
+    EndTurnAction(),
+    AIRegistry,
+  );
+
+  expect(snapshotGameState(gameStateB)).toMatchInlineSnapshot(`
+    "Heal (2,1 → 1,1)
+    CompleteUnit (1,1)
+    CompleteUnit (3,1)
+    CompleteUnit (1,3)
+    EndTurn { current: { funds: 680, player: 2 }, next: { funds: 0, player: 1 }, round: 3, rotatePlayers: null, supply: null, miss: null }"
+  `);
+});
+
+test('AI will limit healing to maintain an economic reserve', async () => {
+  const initialMap = withModifiers(
+    MapData.createMap({
+      map: [1, 1, 1, 1, 1, 1, 1, 1, 1],
+      size: {
+        height: 3,
+        width: 3,
+      },
+      teams: [
+        { id: 1, name: '', players: [{ funds: 0, id: 1, userId: '1' }] },
+        { id: 2, name: '', players: [{ funds: 400, id: 2, name: 'Bot' }] },
+      ],
+    }),
+  );
+
+  const map = withModifiers(
+    initialMap.copy({
+      buildings: initialMap.buildings.set(vec(1, 1), House.create(2)),
+      units: initialMap.units
+        .set(vec(1, 1), Medic.create(2).setHealth(50))
+        .set(vec(1, 2), Medic.create(2).setHealth(50))
+        .set(vec(2, 1), Medic.create(2).setHealth(50))
+        .set(vec(2, 2), Medic.create(2).setHealth(50))
+        .set(vec(3, 3), FighterJet.create(1)),
+    }),
+  );
+
+  const [, , gameStateA] = await executeGameAction(
+    map,
+    map.createVisionObject(player1),
+    new Map(),
+    EndTurnAction(),
+    AIRegistry,
+  );
+
+  expect(snapshotGameState(gameStateA)).toMatchInlineSnapshot(`
+    "Heal (1,1 → 2,1)
+    Heal (1,2 → 1,1)
+    Move (2,1 → 3,2) { fuel: 78, completed: null, path: [3,1 → 3,2] }
+    CompleteUnit (2,2)
+    EndTurn { current: { funds: 300, player: 2 }, next: { funds: 0, player: 1 }, round: 2, rotatePlayers: null, supply: null, miss: null }"
   `);
 });

--- a/tests/__tests__/AIBehavior.test.tsx
+++ b/tests/__tests__/AIBehavior.test.tsx
@@ -1246,7 +1246,7 @@ test('AI will prioritize healing own units currently transporting other units', 
       units: initialMap.units
         .set(vec(1, 1), Hovercraft.create(2).setHealth(50))
         .set(vec(1, 2), Infantry.create(2))
-        .set(vec(1, 3), Hovercraft.create(2).setHealth(80))
+        .set(vec(1, 3), Hovercraft.create(2).setHealth(50))
         .set(vec(2, 2), SupportShip.create(2))
         .set(vec(3, 1), Hovercraft.create(2).setHealth(50))
         .set(vec(3, 3), FighterJet.create(1)),
@@ -1281,7 +1281,8 @@ test('AI will prioritize healing own units currently transporting other units', 
   );
 
   expect(snapshotGameState(gameStateB)).toMatchInlineSnapshot(`
-    "Heal (2,1 → 1,1)
+    "Move (2,1 → 2,3) { fuel: 85, completed: null, path: [2,2 → 2,3] }
+    Heal (2,3 → 1,3)
     CompleteUnit (1,1)
     CompleteUnit (3,1)
     CompleteUnit (1,3)


### PR DESCRIPTION
My attempt at completing #4, or at least the healing part of the issue. Doesn't touch the AI's decision-making for creating new medics and support ships.

Adds a new function `healUnit` and places it in the action loop after `rescue` and before `attack`. Weighting for prioritising which unit to heal is in `getHealingWeight.tsx`.

I've also added three tests to ensure it works in `AIBehaviour.tsx`: 
 - one for checking if it will prioritise own units with labels, 
 - one for prioritising units transporting other units, 
 - and the last to make sure it doesn't just spend all its money.